### PR TITLE
Catch exceptions from Document setter functions and log errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "event-stream": "^3.3.2",
     "jshint": "^2.8.0",
     "precommit-hook": "^3.0.0",
-    "pelias-model": "git://github.com/pelias/model.git#c97cf830d4fe9cb8333f714ee70a72b476779e9c",
+    "pelias-model": "1.0.0",
     "tap-dot": "^1.0.1",
     "tape": "^4.2.2"
   },

--- a/test/lookupStreamTest.js
+++ b/test/lookupStreamTest.js
@@ -329,4 +329,39 @@ tape('tests', function(test) {
 
   });
 
+  test.test('empty string in place name should not error', function(t) {
+    var inputDoc = new Document( 'whosonfirst', 'placetype', '1')
+      .setCentroid({ lat: 12.121212, lon: 21.212121 });
+
+    var expectedDoc = new Document( 'whosonfirst', 'placetype', '1')
+      .setAlpha3('DNK')
+      .setCentroid({ lat: 12.121212, lon: 21.212121 })
+      .setAdmin( 'admin0', 'Denmark')
+      .addParent( 'country', 'Denmark', '1');
+
+    var resolver = function(centroid, callback) {
+      var result = {
+        country: [
+          { id: 1, name: 'Denmark'}
+        ],
+        county: [
+          { id: 2, name: '' }
+        ]
+      };
+
+      setTimeout(callback, 0, null, result);
+
+    };
+
+    var lookupStream = stream.createLookupStream(resolver);
+
+    t.doesNotThrow( function () {
+
+      test_stream([inputDoc], lookupStream, function (err, actual) {
+        t.deepEqual(actual, [expectedDoc], 'county should not be set');
+        t.end();
+      });
+    });
+
+  });
 });


### PR DESCRIPTION
When the name of a place is an empty string the Document setter function get super annoyed and throws an exception. These aren't fatal, so catching them and logging to the suspect file so we can keep track of problems is good enough.