### PR TITLE
Add end function call to lookup processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# Webstorm IDE files
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pelias-wof-admin-lookup",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A fast, local, streaming Who's On First administrative hierarchy lookup.",
   "main": "index.js",
   "scripts": {
@@ -19,7 +19,7 @@
     "lodash": "^3.10.1",
     "pelias-config": "^1.0.3",
     "pelias-logger": "0.0.8",
-    "pelias-parallel-stream": "0.0.1",
+    "pelias-parallel-stream": "0.0.2",
     "pelias-wof-pip-service": "1.0.4",
     "request": "^2.67.0",
     "through2": "^2.0.0"
@@ -28,8 +28,8 @@
     "event-stream": "^3.3.2",
     "intercept-stdout": "^0.1.2",
     "jshint": "^2.8.0",
-    "precommit-hook": "^3.0.0",
     "pelias-model": "1.0.1",
+    "precommit-hook": "^3.0.0",
     "tap-dot": "^1.0.1",
     "tape": "^4.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pelias-wof-admin-lookup",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A fast, local, streaming Who's On First administrative hierarchy lookup.",
   "main": "index.js",
   "scripts": {

--- a/src/httpPipResolver.js
+++ b/src/httpPipResolver.js
@@ -4,66 +4,75 @@ var request = require('request');
 var peliasConfig = require( 'pelias-config' ).generate();
 var _ = require('lodash');
 
-function createWofPipResolver(url, config) {
-  // prepend url with 'http://' if not already
-  var normalizedUrl = _.startsWith(url, 'http://') ? url : 'http://' + url;
-  config = config || peliasConfig;
 
-  var maxConcurrentReqs = 1;
-  if (config.imports.adminLookup && config.imports.adminLookup.maxConcurrentReqs) {
-    maxConcurrentReqs = config.imports.adminLookup.maxConcurrentReqs;
+function RemotePIPResolver(url, config) {
+  // prepend url with 'http://' if not already
+  this.normalizedUrl = _.startsWith(url, 'http://') ? url : 'http://' + url;
+  this.config = config || peliasConfig;
+
+  this.maxConcurrentReqs = 1;
+  if (this.config.imports.adminLookup && this.config.imports.adminLookup.maxConcurrentReqs) {
+    this.maxConcurrentReqs = this.config.imports.adminLookup.maxConcurrentReqs;
   }
 
-  var httpAgent = new http.Agent({
+  this.httpAgent = new http.Agent({
     keepAlive: true,
-    maxSockets: maxConcurrentReqs
+    maxSockets: this.maxConcurrentReqs
   });
+}
 
-  return function(centroid, callback) {
-    var urlPath = util.format('%s/?latitude=%d&longitude=%d', normalizedUrl, centroid.lat, centroid.lon);
+RemotePIPResolver.prototype.lookup = function lookup(centroid, callback) {
+  var urlPath = util.format('%s/?latitude=%d&longitude=%d',
+    this.normalizedUrl, centroid.lat, centroid.lon);
 
-    var options = {
-      method: 'GET',
-      url: urlPath,
-      agent: httpAgent
-    };
-
-    request(options, function (err, res, body) {
-      // if an error occurred attempting to connect, handle it
-      if (err) {
-        console.error(err.stack);
-        return callback(err, null);
-      }
-
-      // handle condition where a non-200 was returned
-      if (res.statusCode !== 200) {
-        var error = {
-          centroid: centroid,
-          statusCode: res.statusCode,
-          text: body
-        };
-
-        console.error(JSON.stringify(error));
-        return callback(error, null);
-      }
-
-      // convert the array to an object keyed on the array element's Placetype field
-      var result = JSON.parse(body).reduce(function (obj, elem) {
-        if (!obj.hasOwnProperty(elem.Placetype)) {
-          obj[elem.Placetype] = [];
-        }
-        obj[elem.Placetype].push({
-          id: elem.Id,
-          name: elem.Name
-        });
-        return obj;
-      }, {});
-
-      return callback(null, result);
-
-    });
+  var options = {
+    method: 'GET',
+    url: urlPath,
+    agent: this.httpAgent
   };
 
+  request(options, function (err, res, body) {
+    // if an error occurred attempting to connect, handle it
+    if (err) {
+      console.error(err.stack);
+      return callback(err, null);
+    }
+
+    // handle condition where a non-200 was returned
+    if (res.statusCode !== 200) {
+      var error = {
+        centroid: centroid,
+        statusCode: res.statusCode,
+        text: body
+      };
+
+      console.error(JSON.stringify(error));
+      return callback(error, null);
+    }
+
+    // convert the array to an object keyed on the array element's Placetype field
+    var result = JSON.parse(body).reduce(function (obj, elem) {
+      if (!obj.hasOwnProperty(elem.Placetype)) {
+        obj[elem.Placetype] = [];
+      }
+      obj[elem.Placetype].push({
+        id: elem.Id,
+        name: elem.Name
+      });
+      return obj;
+    }, {});
+
+    return callback(null, result);
+
+  });
+};
+
+RemotePIPResolver.prototype.end = function end() {
+  // nothing to do here
+};
+
+function createWofPipResolver(url, config) {
+  return new RemotePIPResolver(url, config);
 }
 
 module.exports = createWofPipResolver;

--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -86,6 +86,10 @@ function hasAnyMultiples(result) {
 
 function createLookupStream(resolver, config) {
 
+  if (!resolver) {
+    throw new Error('createLookupStream requires a valid resolver to be passed in as the first parameter');
+  }
+
   config = config || peliasConfig;
 
   var maxConcurrentReqs = 1;
@@ -100,7 +104,7 @@ function createLookupStream(resolver, config) {
       return callback(null, doc);
     }
 
-    resolver(doc.getCentroid(), function (err, result) {
+    resolver.lookup(doc.getCentroid(), function (err, result) {
 
       // assume errors at this point are fatal, so pass them upstream to kill stream
       if (err) {
@@ -145,14 +149,7 @@ function createLookupStream(resolver, config) {
 
       callback(null, doc);
     });
-  });
-
-  if (resolver && typeof resolver.end === 'function') {
-    logger.debug('Adding stream end handler to adminLookup stream');
-    stream.on('finish', function () {
-      resolver.end();
-    });
-  }
+  }, resolver.end);
 
   return stream;
 }

--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -151,7 +151,12 @@ function createLookupStream(resolver, config) {
 
       callback(null, doc);
     });
-  }, resolver.end);
+  },
+  function end() {
+    if (typeof resolver.end === 'function') {
+      resolver.end();
+    }
+  });
 
   return stream;
 }

--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -93,7 +93,7 @@ function createLookupStream(resolver, config) {
     maxConcurrentReqs = config.imports.adminLookup.maxConcurrentReqs;
   }
 
-  return parallelStream(maxConcurrentReqs, function (doc, enc, callback) {
+  var stream = parallelStream(maxConcurrentReqs, function (doc, enc, callback) {
 
     // don't do anything if there's no centroid
     if (_.isEmpty(doc.getCentroid())) {
@@ -146,6 +146,15 @@ function createLookupStream(resolver, config) {
       callback(null, doc);
     });
   });
+
+  if (resolver && typeof resolver.end === 'function') {
+    logger.debug('Adding stream end handler to adminLookup stream');
+    stream.on('finish', function () {
+      resolver.end();
+    });
+  }
+
+  return stream;
 }
 
 module.exports = {

--- a/test/lookupStreamTest.js
+++ b/test/lookupStreamTest.js
@@ -445,4 +445,20 @@ tape('tests', function(test) {
 
   });
 
+  test.test('call end to stop child processes', function (t) {
+    t.plan(1);
+
+    var resolver = {
+      end: function () {
+        t.assert(true, 'called end function');
+      }
+    };
+
+    var lookupStream = stream.createLookupStream(resolver);
+
+    lookupStream.end();
+
+    t.end();
+  });
+
 });

--- a/test/lookupStreamTest.js
+++ b/test/lookupStreamTest.js
@@ -458,11 +458,12 @@ tape('tests', function(test) {
   });
 
   test.test('call end to stop child processes', function (t) {
-    t.plan(1);
+    t.plan(2);
 
     var resolver = {
       end: function () {
         t.assert(true, 'called end function');
+        t.equals(resolver, this, 'this is set to the correct object');
         t.end();
       }
     };

--- a/test/lookupStreamTest.js
+++ b/test/lookupStreamTest.js
@@ -18,7 +18,7 @@ tape('tests', function(test) {
       new Document( 'whosonfirst', 'placetype', '1')
     ];
 
-    var lookupStream = stream.createLookupStream();
+    var lookupStream = stream.createLookupStream({});
 
     test_stream(input, lookupStream, function(err, actual) {
       t.deepEqual(actual, input, 'nothing should have changed');
@@ -51,44 +51,45 @@ tape('tests', function(test) {
         .addParent('neighbourhood', 'Neighbourhood 1', '15')
     ];
 
-    var resolver = function(centroid, callback) {
-      var result = {
-        country: [
-          { id: 1, name: 'Country 1'},
-          { id: 2, name: 'Country 2'}
-        ],
-        macroregion: [
-          { id: 3, name: 'Macroregion 1'},
-          { id: 4, name: 'Macroregion 2'}
-        ],
-        region: [
-          { id: 5, name: 'Region 1'},
-          { id: 6, name: 'Region 2'}
-        ],
-        macrocounty: [
-          { id: 7, name: 'Macrocounty 1'},
-          { id: 8, name: 'Macrocounty 2'}
-        ],
-        county: [
-          { id: 9, name: 'County 1'},
-          { id: 10, name: 'County 2'}
-        ],
-        locality: [
-          { id: 11, name: 'Locality 1'},
-          { id: 12, name: 'Locality 2'}
-        ],
-        localadmin: [
-          { id: 13, name: 'LocalAdmin 1'},
-          { id: 14, name: 'LocalAdmin 2'}
-        ],
-        neighbourhood: [
-          { id: 15, name: 'Neighbourhood 1'},
-          { id: 16, name: 'Neighbourhood 2'}
-        ]
-      };
+    var resolver = {
+      lookup: function (centroid, callback) {
+        var result = {
+          country: [
+            {id: 1, name: 'Country 1'},
+            {id: 2, name: 'Country 2'}
+          ],
+          macroregion: [
+            {id: 3, name: 'Macroregion 1'},
+            {id: 4, name: 'Macroregion 2'}
+          ],
+          region: [
+            {id: 5, name: 'Region 1'},
+            {id: 6, name: 'Region 2'}
+          ],
+          macrocounty: [
+            {id: 7, name: 'Macrocounty 1'},
+            {id: 8, name: 'Macrocounty 2'}
+          ],
+          county: [
+            {id: 9, name: 'County 1'},
+            {id: 10, name: 'County 2'}
+          ],
+          locality: [
+            {id: 11, name: 'Locality 1'},
+            {id: 12, name: 'Locality 2'}
+          ],
+          localadmin: [
+            {id: 13, name: 'LocalAdmin 1'},
+            {id: 14, name: 'LocalAdmin 2'}
+          ],
+          neighbourhood: [
+            {id: 15, name: 'Neighbourhood 1'},
+            {id: 16, name: 'Neighbourhood 2'}
+          ]
+        };
 
-      setTimeout(callback, 0, null, result);
-
+        setTimeout(callback, 0, null, result);
+      }
     };
 
     var lookupStream = stream.createLookupStream(resolver);
@@ -119,13 +120,14 @@ tape('tests', function(test) {
         .addParent('country', 'Country', '2')
     ];
 
-    var resolver = function(centroid, callback) {
-      if (_.isEqual(centroid, { lat: 12.121212, lon: 21.212121 } )) {
-        setTimeout(callback, 0, null, { region: [ { id: 1, name: 'Region' } ] });
-      } else if (_.isEqual(centroid, { lat: 13.131313, lon: 31.313131 })) {
-        setTimeout(callback, 0, null, { country: [ {id: 2, name: 'Country' } ] });
+    var resolver = {
+      lookup: function (centroid, callback) {
+        if (_.isEqual(centroid, {lat: 12.121212, lon: 21.212121})) {
+          setTimeout(callback, 0, null, {region: [{id: 1, name: 'Region'}]});
+        } else if (_.isEqual(centroid, {lat: 13.131313, lon: 31.313131})) {
+          setTimeout(callback, 0, null, {country: [{id: 2, name: 'Country'}]});
+        }
       }
-
     };
 
     var lookupStream = stream.createLookupStream(resolver);
@@ -144,8 +146,10 @@ tape('tests', function(test) {
     var expected = new Document( 'whosonfirst', 'placetype', '1')
         .setCentroid({ lat: 12.121212, lon: 21.212121 });
 
-    var resolver = function(centroid, callback) {
-      setTimeout(callback, 0, 'this is an error', { region: 'Region' } );
+    var resolver = {
+      lookup: function (centroid, callback) {
+        setTimeout(callback, 0, 'this is an error', {region: 'Region'});
+      }
     };
 
     var config = {
@@ -182,18 +186,19 @@ tape('tests', function(test) {
         .addParent('region', 'Pennsylvania', '3', 'PA')
     ];
 
-    var resolver = function(centroid, callback) {
-      var result = {
-        country: [
-          { id: 1, name: 'United States'}
-        ],
-        region: [
-          { id: 3, name: 'Pennsylvania'}
-        ]
-      };
+    var resolver = {
+      lookup: function(centroid, callback) {
+        var result = {
+          country: [
+            {id: 1, name: 'United States'}
+          ],
+          region: [
+            {id: 3, name: 'Pennsylvania'}
+          ]
+        };
 
-      setTimeout(callback, 0, null, result);
-
+        setTimeout(callback, 0, null, result);
+      }
     };
 
     var lookupStream = stream.createLookupStream(resolver);
@@ -220,18 +225,19 @@ tape('tests', function(test) {
         .addParent('region', 'unknown US state', '3')
     ];
 
-    var resolver = function(centroid, callback) {
-      var result = {
-        country: [
-          { id: 1, name: 'United States'}
-        ],
-        region: [
-          { id: 3, name: 'unknown US state'}
-        ]
-      };
+    var resolver = {
+      lookup: function(centroid, callback) {
+        var result = {
+          country: [
+            {id: 1, name: 'United States'}
+          ],
+          region: [
+            {id: 3, name: 'unknown US state'}
+          ]
+        };
 
-      setTimeout(callback, 0, null, result);
-
+        setTimeout(callback, 0, null, result);
+      }
     };
 
     var lookupStream = stream.createLookupStream(resolver);
@@ -257,18 +263,19 @@ tape('tests', function(test) {
         .addParent('region', 'Pennsylvania', '3')
     ];
 
-    var resolver = function(centroid, callback) {
-      var result = {
-        country: [
-          { id: 1, name: 'unsupported country'}
-        ],
-        region: [
-          { id: 3, name: 'Pennsylvania'}
-        ]
-      };
+    var resolver = {
+      lookup: function (centroid, callback) {
+        var result = {
+          country: [
+            {id: 1, name: 'unsupported country'}
+          ],
+          region: [
+            {id: 3, name: 'Pennsylvania'}
+          ]
+        };
 
-      setTimeout(callback, 0, null, result);
-
+        setTimeout(callback, 0, null, result);
+      }
     };
 
     var lookupStream = stream.createLookupStream(resolver);
@@ -289,15 +296,16 @@ tape('tests', function(test) {
         .setAdmin( 'locality', 'Locality')
         .addParent( 'locality', 'Locality', '1');
 
-    var resolver = function(centroid, callback) {
-      var result = {
-        locality: [
-          { id: 1, name: 'Locality'}
-        ]
-      };
+    var resolver = {
+      lookup: function(centroid, callback) {
+        var result = {
+          locality: [
+            {id: 1, name: 'Locality'}
+          ]
+        };
 
-      setTimeout(callback, 0, null, result);
-
+        setTimeout(callback, 0, null, result);
+      }
     };
 
     var lookupStream = stream.createLookupStream(resolver);
@@ -319,15 +327,16 @@ tape('tests', function(test) {
         .setAdmin( 'admin0', 'Denmark')
         .addParent( 'country', 'Denmark', '1');
 
-    var resolver = function(centroid, callback) {
-      var result = {
-        country: [
-          { id: 1, name: 'Denmark'}
-        ]
-      };
+    var resolver = {
+      lookup: function(centroid, callback) {
+        var result = {
+          country: [
+            {id: 1, name: 'Denmark'}
+          ]
+        };
 
-      setTimeout(callback, 0, null, result);
-
+        setTimeout(callback, 0, null, result);
+      }
     };
 
     var lookupStream = stream.createLookupStream(resolver);
@@ -349,18 +358,19 @@ tape('tests', function(test) {
       .setAdmin( 'admin0', 'Denmark')
       .addParent( 'country', 'Denmark', '1');
 
-    var resolver = function(centroid, callback) {
-      var result = {
-        country: [
-          { id: 1, name: 'Denmark'}
-        ],
-        county: [
-          { id: 2, name: '' }
-        ]
-      };
+    var resolver = {
+      lookup: function(centroid, callback) {
+        var result = {
+          country: [
+            {id: 1, name: 'Denmark'}
+          ],
+          county: [
+            {id: 2, name: ''}
+          ]
+        };
 
-      setTimeout(callback, 0, null, result);
-
+        setTimeout(callback, 0, null, result);
+      }
     };
 
     var lookupStream = stream.createLookupStream(resolver);
@@ -387,16 +397,17 @@ tape('tests', function(test) {
         .addParent('region', 'Dependency 1', '11')
     ];
 
-    var resolver = function(centroid, callback) {
-      var result = {
-        dependency: [
-          { id: 11, name: 'Dependency 1'},
-          { id: 12, name: 'Dependency 2'}
-        ]
-      };
+    var resolver = {
+      lookup: function(centroid, callback) {
+        var result = {
+          dependency: [
+            {id: 11, name: 'Dependency 1'},
+            {id: 12, name: 'Dependency 2'}
+          ]
+        };
 
-      setTimeout(callback, 0, null, result);
-
+        setTimeout(callback, 0, null, result);
+      }
     };
 
     var lookupStream = stream.createLookupStream(resolver);
@@ -420,20 +431,21 @@ tape('tests', function(test) {
         .addParent('region', 'Region 1', '11')
     ];
 
-    var resolver = function(centroid, callback) {
-      var result = {
-        region: [
-          { id: 11, name: 'Region 1'},
-          { id: 12, name: 'Region 2'}
-        ],
-        dependency: [
-          { id: 13, name: 'Dependency 1'},
-          { id: 14, name: 'Dependency 2'}
-        ]
-      };
+    var resolver = {
+      lookup: function(centroid, callback) {
+        var result = {
+          region: [
+            {id: 11, name: 'Region 1'},
+            {id: 12, name: 'Region 2'}
+          ],
+          dependency: [
+            {id: 13, name: 'Dependency 1'},
+            {id: 14, name: 'Dependency 2'}
+          ]
+        };
 
-      setTimeout(callback, 0, null, result);
-
+        setTimeout(callback, 0, null, result);
+      }
     };
 
     var lookupStream = stream.createLookupStream(resolver);
@@ -451,14 +463,13 @@ tape('tests', function(test) {
     var resolver = {
       end: function () {
         t.assert(true, 'called end function');
+        t.end();
       }
     };
 
     var lookupStream = stream.createLookupStream(resolver);
-
     lookupStream.end();
 
-    t.end();
   });
 
 });

--- a/test/resolversFactoryLocalTest.js
+++ b/test/resolversFactoryLocalTest.js
@@ -59,7 +59,7 @@ tape('tests', function(test) {
       t.end();
     };
 
-    resolver(centroid, callback);
+    resolver.lookup(centroid, callback);
 
   });
 

--- a/test/resolversFactoryLocalTest.js
+++ b/test/resolversFactoryLocalTest.js
@@ -6,6 +6,9 @@ tape('tests', function(test) {
 
   function makeLookupMock(t, expected, err, res) {
     return {
+      end: function () {
+        t.assert(true, 'called end function');
+      },
       lookup: function (lat, lon, callback) {
         t.equal(lat, expected.lat, 'correct latitude is passed');
         t.equal(lon, expected.lon, 'correct longitude is passed');
@@ -15,6 +18,8 @@ tape('tests', function(test) {
   }
 
   test.test('return value should be parsed from server response', function(t) {
+    t.plan(3);
+
     var centroid = {
       lon: -123.145257,
       lat: 49.270478

--- a/test/resolversFactoryTest.js
+++ b/test/resolversFactoryTest.js
@@ -126,7 +126,7 @@ tape('tests', function(test) {
 
     };
 
-    resolver(centroid, callback);
+    resolver.lookup(centroid, callback);
 
   });
 
@@ -175,7 +175,7 @@ tape('tests', function(test) {
 
     };
 
-    resolver(centroid, callback);
+    resolver.lookup(centroid, callback);
 
   });
 
@@ -205,7 +205,7 @@ tape('tests', function(test) {
 
     };
 
-    resolver(centroid, callback);
+    resolver.lookup(centroid, callback);
 
   });
 
@@ -256,7 +256,7 @@ tape('tests', function(test) {
 
     };
 
-    resolver(centroid, callback);
+    resolver.lookup(centroid, callback);
 
   });
 


### PR DESCRIPTION
Add stream-end handling in order to shut down local pip child processes

Refactored the resolvers to be classes with `lookup` and `end` functions. Invoke `end` function in the parallel-stream stream-end-handler.