### PR TITLE
Bumping pelias-model version for test dependecies only

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "intercept-stdout": "^0.1.2",
     "jshint": "^2.8.0",
     "precommit-hook": "^3.0.0",
-    "pelias-model": "1.0.1",
+    "pelias-model": "2.0.0",
     "tap-dot": "^1.0.1",
     "tape": "^4.2.2"
   },


### PR DESCRIPTION
No need to bump package version here.

Connected to pelias/api#424