### PR TITLE
Allow configuring admin fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pelias-config": "^1.0.3",
     "pelias-logger": "0.0.8",
     "pelias-parallel-stream": "0.0.2",
-    "pelias-wof-pip-service": "1.0.6",
+    "pelias-wof-pip-service": "1.1.1",
     "request": "^2.67.0",
     "through2": "^2.0.0"
   },

--- a/src/getAdminLayers.js
+++ b/src/getAdminLayers.js
@@ -1,0 +1,24 @@
+/* Look up which admin fields should be populated for a record in a given layer.
+ *
+ * The logic is: look up eveything above in the WOF heirarchy, ignoring things like
+ * 'dependency'
+ *
+ * Note: this filtering really only matters for geonames currently, since OSM and OA
+ * consist entirely of venue and address records, which should have all fields
+ * looked up. WOF documents use the actual WOF heirarchy to fill in admin values,
+ * so they also won't be affected by this.
+ */
+function getAdminLayers(layer) {
+  switch (layer) {
+    case 'region':
+        return ['country', 'macroregion'];
+    case 'county':
+        return ['country', 'macroregion', 'region', 'macrocounty'];
+    case 'locality':
+        return ['country', 'macroregion', 'region', 'macrocounty', 'county'];
+    default:
+        return undefined;//undefined means use all layers as normal
+  }
+}
+
+module.exports = getAdminLayers;

--- a/src/localPipResolver.js
+++ b/src/localPipResolver.js
@@ -29,11 +29,11 @@ LocalPIPService.prototype.lookup = function lookup(centroid, callback) {
 
   var self = this;
 
-  // in the case that the lookup service hasn't loaded yet, sleep and come back in 30 seconds
+  // in the case that the lookup service hasn't loaded yet, sleep and come back in 5 seconds
   if (!self.lookupService) {
     setTimeout(function () {
       self.lookup(centroid, callback);
-    }, 1000 * 30);
+    }, 1000 * 5);
     return;
   }
 

--- a/src/localPipResolver.js
+++ b/src/localPipResolver.js
@@ -25,7 +25,7 @@ function LocalPIPService(lookupService) {
  * @param {number} centroid.lon
  * @param callback
  */
-LocalPIPService.prototype.lookup = function lookup(centroid, callback) {
+LocalPIPService.prototype.lookup = function lookup(centroid, callback, search_layers) {
 
   var self = this;
 
@@ -52,7 +52,7 @@ LocalPIPService.prototype.lookup = function lookup(centroid, callback) {
     }, {});
 
     callback(err, result);
-  });
+  }, search_layers);
 };
 
 /**

--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -4,7 +4,7 @@ var peliasConfig = require( 'pelias-config' ).generate();
 var countries = require('../data/countries');
 var regions = require('../data/regions');
 var peliasLogger = require( 'pelias-logger' );
-
+var getAdminLayers = require( './getAdminLayers' );
 
 var logger = peliasLogger.get( 'wof-admin-lookup', {
   transports: [
@@ -150,7 +150,7 @@ function createLookupStream(resolver, config) {
       setFields(result.neighbourhood, doc, 'neighborhood', 'neighbourhood');
 
       callback(null, doc);
-    });
+    }, getAdminLayers(doc.getLayer()));
   },
   function end() {
     if (typeof resolver.end === 'function') {


### PR DESCRIPTION
Depends on with pelias/wof-pip-service#6, and together with it allows specifying which admin fields to look up for a given record.

Connects pelias/geonames#35