### PR TITLE
Correct admin lookup layers for Geonames

### DIFF
--- a/src/getAdminLayers.js
+++ b/src/getAdminLayers.js
@@ -11,11 +11,11 @@
 function getAdminLayers(layer) {
   switch (layer) {
     case 'region':
-        return ['country', 'macroregion'];
+        return ['country', 'macroregion', 'region'];
     case 'county':
-        return ['country', 'macroregion', 'region', 'macrocounty'];
-    case 'locality':
         return ['country', 'macroregion', 'region', 'macrocounty', 'county'];
+    case 'locality':
+        return ['country', 'macroregion', 'region', 'macrocounty', 'county', 'locality'];
     default:
         return undefined;//undefined means use all layers as normal
   }


### PR DESCRIPTION
The API label code expects that any record has admin lookup fields up to
and including the layer of the record itself. For example, regions
should have the region and region_a fields filled in by admin lookup.