### PR TITLE
Add country to admin layers filtering

### DIFF
--- a/src/getAdminLayers.js
+++ b/src/getAdminLayers.js
@@ -10,6 +10,8 @@
  */
 function getAdminLayers(layer) {
   switch (layer) {
+    case 'country':
+        return ['country'];
     case 'region':
         return ['country', 'macroregion', 'region'];
     case 'county':


### PR DESCRIPTION
This was missing, which would cause countries to get all admin layers.


fixes pelias/geonames#25