### PR TITLE
Improve layer mapping

### DIFF
--- a/src/getAdminLayers.js
+++ b/src/getAdminLayers.js
@@ -12,6 +12,8 @@ function getAdminLayers(layer) {
   switch (layer) {
     case 'country':
         return ['country'];
+    case 'macroregion':
+        return ['country', 'macroregion'];
     case 'region':
         return ['country', 'macroregion', 'region'];
     case 'county':

--- a/src/getAdminLayers.js
+++ b/src/getAdminLayers.js
@@ -17,7 +17,7 @@ function getAdminLayers(layer) {
     case 'county':
         return ['country', 'macroregion', 'region', 'macrocounty', 'county'];
     case 'locality':
-        return ['country', 'macroregion', 'region', 'macrocounty', 'county', 'locality', 'borough'];
+        return ['country', 'macroregion', 'region', 'macrocounty', 'county', 'locality'];
     default:
         return undefined;//undefined means use all layers as normal
   }


### PR DESCRIPTION
Fix some issues with the choices of which layers to perform admin lookup against.

Removes borough lookup from locality, which was something we should never have added.

Fixes pelias/geonames#73 by only looking up macroregion records against macroregion.