### PR TITLE
Speed up tests by explicitly closing connections on end

### DIFF
--- a/src/httpPipResolver.js
+++ b/src/httpPipResolver.js
@@ -68,7 +68,7 @@ RemotePIPResolver.prototype.lookup = function lookup(centroid, callback) {
 };
 
 RemotePIPResolver.prototype.end = function end() {
-  // nothing to do here
+  this.httpAgent.destroy();
 };
 
 function createWofPipResolver(url, config) {

--- a/test/resolversFactoryTest.js
+++ b/test/resolversFactoryTest.js
@@ -136,6 +136,7 @@ tape('tests', function(test) {
       t.deepEqual(result, expected);
       t.equal(stderr, '', 'nothing should have been written to stderr');
       t.end();
+      resolver.end();
       server.close();
 
     };
@@ -185,6 +186,7 @@ tape('tests', function(test) {
       t.deepEqual(result, expected);
       t.equal(stderr, '', 'nothing should have been written to stderr');
       t.end();
+      resolver.end();
       server.close();
 
     };
@@ -267,6 +269,7 @@ tape('tests', function(test) {
 
       t.end();
       server.close();
+      resolver.end();
 
     };
 


### PR DESCRIPTION
To avoid the overhead of reinitializing HTTP connections when using an
HTTP PIP resolver, we use an HTTP agent with connection keepAlive set to
true.
    
However, avoiding explicitly closing these connections uses extra
resources on the server (the server will assume the connection is open
after the resolver is done with it's work). This effect is minor but we
might as well fix it.
    
A more important effect of this change is that it drastically speeds up
our tests! Previously, the HTTP server we created for the tests would
wait for a full 2 minutes after the tests were done before closing the
connection and shutting down. Now that the connection is explicitly
closed by the resolver, the Node process can exit immediately after the
last test is finished! 🏇

See the HTTP [agent.destroy()](https://nodejs.org/api/http.html#http_agent_destroy) docs for more info.
    
Fixes #42
