### PR TITLE
Lookup only higher admin layers

### DIFF
--- a/src/getAdminLayers.js
+++ b/src/getAdminLayers.js
@@ -18,8 +18,10 @@ function getAdminLayers(layer) {
         return ['country', 'macroregion'];
     case 'county':
         return ['country', 'macroregion', 'region', 'macrocounty'];
-    case 'locality':
+    case 'localadmin':
         return ['country', 'macroregion', 'region', 'macrocounty', 'county'];
+    case 'locality':
+        return ['country', 'macroregion', 'region', 'macrocounty', 'county', 'localadmin'];
     default:
         return undefined;//undefined means use all layers as normal
   }

--- a/src/getAdminLayers.js
+++ b/src/getAdminLayers.js
@@ -11,15 +11,15 @@
 function getAdminLayers(layer) {
   switch (layer) {
     case 'country':
-        return ['country'];
+        return []; // No admin lookup needed for countries!
     case 'macroregion':
-        return ['country', 'macroregion'];
+        return ['country'];
     case 'region':
-        return ['country', 'macroregion', 'region'];
+        return ['country', 'macroregion'];
     case 'county':
-        return ['country', 'macroregion', 'region', 'macrocounty', 'county'];
+        return ['country', 'macroregion', 'region', 'macrocounty'];
     case 'locality':
-        return ['country', 'macroregion', 'region', 'macrocounty', 'county', 'locality'];
+        return ['country', 'macroregion', 'region', 'macrocounty', 'county'];
     default:
         return undefined;//undefined means use all layers as normal
   }


### PR DESCRIPTION
Our label generation code previously required that an admin record had admin lookup performed at the same level it was at. The idea that we would ask, for example, what locality this locality is in was weird, and fortunately now it's no longer required. In fact it adds extra sections to our Geonames labels. This PR fixes all the issues in #49 by adding a `localadmin` layer setting and ensuring admin records are looked up for layers above that record.

Requires https://github.com/pelias/wof-pip-service/pull/37 in wof-pip-service first

Fixes #49 