### PR TITLE
Handle localadmin layer

### DIFF
--- a/src/getAdminLayers.js
+++ b/src/getAdminLayers.js
@@ -18,6 +18,8 @@ function getAdminLayers(layer) {
         return ['country', 'macroregion', 'region'];
     case 'county':
         return ['country', 'macroregion', 'region', 'macrocounty', 'county'];
+    case 'localadmin':
+        return ['country', 'macroregion', 'region', 'macrocounty', 'county', 'localadmin'];
     case 'locality':
         return ['country', 'macroregion', 'region', 'macrocounty', 'county', 'localadmin', 'locality'];
     default:

--- a/src/getAdminLayers.js
+++ b/src/getAdminLayers.js
@@ -19,7 +19,7 @@ function getAdminLayers(layer) {
     case 'county':
         return ['country', 'macroregion', 'region', 'macrocounty', 'county'];
     case 'locality':
-        return ['country', 'macroregion', 'region', 'macrocounty', 'county', 'locality'];
+        return ['country', 'macroregion', 'region', 'macrocounty', 'county', 'localadmin', 'locality'];
     default:
         return undefined;//undefined means use all layers as normal
   }


### PR DESCRIPTION
Previously, locality records did not get looked up against localadmin, which caused missing admin info.

Conversely, localadmin records were looked up against all layers, including locality and neighbourhood, which isn't correct.

This pr is a subset of the changes from #50, with no unexpected side effects regarding abbreviations. It doesn't fix as many label issues though.