### PR TITLE
Use helper scripts to ensure unit tests pass

### DIFF
--- a/bin/units
+++ b/bin/units
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+node test/test.js | ./node_modules/.bin/tap-dot

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A fast, local, streaming Who's On First administrative hierarchy lookup.",
   "main": "index.js",
   "scripts": {
-    "test": "node test/test | tap-dot",
+    "test": "./bin/units",
     "lint": "jshint .",
     "validate": "npm ls",
     "travis": "npm run test"


### PR DESCRIPTION
I saw the error from https://github.com/pelias/api/pull/500 in our
Travis tests for this repo. This PR ensures the test script returns 0.