### PR TITLE
added config validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,11 @@ require('./src/configValidation').validate(peliasConfig);
 
 const _ = require('lodash');
 
-const options = {
-  maxConcurrentReqs: _.get(peliasConfig, 'imports.adminLookup.maxConcurrentReqs', 1),
-  suspectFile: _.get(peliasConfig, 'logger.suspectFile', false)
-};
+const maxConcurrentReqs = _.get(peliasConfig, 'imports.adminLookup.maxConcurrentReqs', 1);
+const datapath = peliasConfig.imports.whosonfirst.datapath;
 
 module.exports = {
-  createLookupStream: require('./src/lookupStream')(options),
-  createWofPipResolver: require('./src/httpPipResolver')(options),
-  createLocalWofPipResolver: require('./src/localPipResolver')(peliasConfig.imports.whosonfirst.datapath)
+  createLookupStream: require('./src/lookupStream')(maxConcurrentReqs),
+  createWofPipResolver: require('./src/httpPipResolver')(maxConcurrentReqs),
+  createLocalWofPipResolver: require('./src/localPipResolver')(datapath)
 };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+const peliasConfig = require('pelias-config').generate();
+require('./src/configValidation').validate(peliasConfig);
+
 var createLookupStream = require('./src/lookupStream');
 var createWofPipResolver = require('./src/resolversFactory');
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,15 @@
 const peliasConfig = require('pelias-config').generate();
 require('./src/configValidation').validate(peliasConfig);
 
-var createLookupStream = require('./src/lookupStream');
-var createWofPipResolver = require('./src/resolversFactory');
+const _ = require('lodash');
+
+const options = {
+  maxConcurrentReqs: _.get(peliasConfig, 'imports.adminLookup.maxConcurrentReqs', 1),
+  suspectFile: _.get(peliasConfig, 'logger.suspectFile', false)
+};
 
 module.exports = {
-  createLookupStream: createLookupStream.createLookupStream,
-  createWofPipResolver: createWofPipResolver.createWofPipResolver,
-  createLocalWofPipResolver: createWofPipResolver.createLocalPipResolver
+  createLookupStream: require('./src/lookupStream')(options),
+  createWofPipResolver: require('./src/httpPipResolver')(options),
+  createLocalWofPipResolver: require('./src/localPipResolver')(peliasConfig.imports.whosonfirst.datapath)
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "who's on first"
   ],
   "dependencies": {
+    "joi": "^10.1.0",
     "lodash": "^4.6.0",
     "pelias-config": "2.4.0",
     "pelias-logger": "0.1.0",
@@ -33,11 +34,12 @@
     "event-stream": "^3.3.2",
     "intercept-stdout": "^0.1.2",
     "jshint": "^2.8.0",
-    "precommit-hook": "^3.0.0",
     "pelias-model": "4.4.0",
+    "precommit-hook": "^3.0.0",
+    "proxyquire": "^1.7.10",
+    "semantic-release": "^6.3.2",
     "tap-dot": "^1.0.1",
-    "tape": "^4.2.2",
-    "semantic-release": "^6.3.2"
+    "tape": "^4.2.2"
   },
   "pre-commit": [
     "lint",

--- a/src/configValidation.js
+++ b/src/configValidation.js
@@ -2,14 +2,18 @@
 
 const Joi = require('joi');
 
-// requires just `maxConcurrentReqs`
+// requires just `imports.whosonfirst.datapath`
+// `imports.adminLookup.maxConcurrentReqs` is optional
 const schema = Joi.object().keys({
-  imports: {
-    adminLookup: {
+  imports: Joi.object().keys({
+    adminLookup: Joi.object().keys({
       maxConcurrentReqs: Joi.number().integer()
-    }
-  }
-}).unknown(true);
+    }),
+    whosonfirst: Joi.object().keys({
+      datapath: Joi.string()
+    }).requiredKeys('datapath').unknown(true)
+  }).requiredKeys('whosonfirst').unknown(true)
+}).requiredKeys('imports').unknown(true);
 
 module.exports = {
   validate: function validate(config) {

--- a/src/configValidation.js
+++ b/src/configValidation.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Joi = require('joi');
+
+// requires just `maxConcurrentReqs`
+const schema = Joi.object().keys({
+  imports: {
+    adminLookup: {
+      maxConcurrentReqs: Joi.number().integer()
+    }
+  }
+}).unknown(true);
+
+module.exports = {
+  validate: function validate(config) {
+    Joi.validate(config, schema, { allowUnknown: true }, (err, value) => {
+      if (err) {
+        throw new Error(err.details[0].message);
+      }
+    });
+  }
+
+};

--- a/src/httpPipResolver.js
+++ b/src/httpPipResolver.js
@@ -3,19 +3,13 @@
 var util = require('util');
 var http = require('http');
 var request = require('request');
-var peliasConfig = require( 'pelias-config' ).generate();
 var _ = require('lodash');
 
+let maxConcurrentReqs;
 
-function RemotePIPResolver(url, config) {
+function RemotePIPResolver(url) {
   // prepend url with 'http://' if not already
   this.normalizedUrl = _.startsWith(url, 'http://') ? url : 'http://' + url;
-  this.config = config || peliasConfig;
-
-  this.maxConcurrentReqs = 1;
-  if (this.config.imports.adminLookup && this.config.imports.adminLookup.maxConcurrentReqs) {
-    this.maxConcurrentReqs = this.config.imports.adminLookup.maxConcurrentReqs;
-  }
 
   this.httpAgent = new http.Agent({
     keepAlive: true,
@@ -80,8 +74,9 @@ RemotePIPResolver.prototype.end = function end() {
   this.httpAgent.destroy();
 };
 
-function createWofPipResolver(url, config) {
-  return new RemotePIPResolver(url, config);
-}
-
-module.exports = createWofPipResolver;
+module.exports = function(options) {
+  maxConcurrentReqs = _.get(options, 'maxConcurrentReqs', 1);
+  return (url) => {
+    return new RemotePIPResolver(url);
+  };
+};

--- a/src/httpPipResolver.js
+++ b/src/httpPipResolver.js
@@ -5,15 +5,13 @@ var http = require('http');
 var request = require('request');
 var _ = require('lodash');
 
-let maxConcurrentReqs;
-
-function RemotePIPResolver(url) {
+function RemotePIPResolver(url, maxConcurrentReqs) {
   // prepend url with 'http://' if not already
   this.normalizedUrl = _.startsWith(url, 'http://') ? url : 'http://' + url;
 
   this.httpAgent = new http.Agent({
     keepAlive: true,
-    maxSockets: this.maxConcurrentReqs
+    maxSockets: maxConcurrentReqs
   });
 }
 
@@ -74,9 +72,8 @@ RemotePIPResolver.prototype.end = function end() {
   this.httpAgent.destroy();
 };
 
-module.exports = function(options) {
-  maxConcurrentReqs = _.get(options, 'maxConcurrentReqs', 1);
+module.exports = function(maxConcurrentReqs) {
   return (url) => {
-    return new RemotePIPResolver(url);
+    return new RemotePIPResolver(url, maxConcurrentReqs);
   };
 };

--- a/src/localPipResolver.js
+++ b/src/localPipResolver.js
@@ -3,6 +3,8 @@
 var logger = require('pelias-logger').get('wof-admin-lookup');
 var createPIPService = require('pelias-wof-pip-service').create;
 
+let datapath;
+
 /**
  * LocalPIPService class
  *
@@ -15,7 +17,7 @@ function LocalPIPService(lookupService) {
 
   if (!this.lookupService) {
     var self = this;
-    createPIPService(function (err, service) {
+    createPIPService(datapath, function (err, service) {
       self.lookupService = service;
     });
   }
@@ -84,4 +86,7 @@ function createLocalPipResolver(service) {
   return new LocalPIPService(service);
 }
 
-module.exports = createLocalPipResolver;
+module.exports = function(_datapath) {
+  datapath = _datapath;
+  return createLocalPipResolver;
+};

--- a/src/localPipResolver.js
+++ b/src/localPipResolver.js
@@ -3,15 +3,13 @@
 var logger = require('pelias-logger').get('wof-admin-lookup');
 var createPIPService = require('pelias-wof-pip-service').create;
 
-let datapath;
-
 /**
  * LocalPIPService class
  *
  * @param {object} [lookupService] optional, primarily used for testing
  * @constructor
  */
-function LocalPIPService(lookupService) {
+function LocalPIPService(lookupService, datapath) {
 
   this.lookupService = lookupService || null;
 
@@ -80,13 +78,11 @@ LocalPIPService.prototype.end = function end() {
  * Factory function
  *
  * @param {object} [service]
+ * @param {string} [datapath]
  * @returns {LocalPIPService}
  */
-function createLocalPipResolver(service) {
-  return new LocalPIPService(service);
-}
-
-module.exports = function(_datapath) {
-  datapath = _datapath;
-  return createLocalPipResolver;
+module.exports = function(datapath) {
+  return function(service) {
+    return new LocalPIPService(service, datapath);
+  };
 };

--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -6,20 +6,15 @@ var regions = require('../data/regions');
 var peliasLogger = require( 'pelias-logger' );
 var getAdminLayers = require( './getAdminLayers' );
 
-let maxConcurrentReqs;
-let suspectFile;
-
 //defaults to nowhere
 var optsArg = {
   transports: []
 };
 //only prints to suspect records log if flag is set
-if (suspectFile){
-  optsArg.transports.push(new peliasLogger.winston.transports.File( {
-    filename: 'suspect_wof_records.log',
-    timestamp: false
-  }));
-}
+optsArg.transports.push(new peliasLogger.winston.transports.File( {
+  filename: 'suspect_wof_records.log',
+  timestamp: false
+}));
 
 var logger = peliasLogger.get( 'wof-admin-lookup', optsArg );
 
@@ -71,7 +66,7 @@ function hasAnyMultiples(result) {
   });
 }
 
-function createLookupStream(resolver) {
+function createLookupStream(resolver, maxConcurrentReqs) {
   if (!resolver) {
     throw new Error('createLookupStream requires a valid resolver to be passed in as the first parameter');
   }
@@ -149,8 +144,8 @@ function getCountryCode(result) {
   return undefined;
 }
 
-module.exports = (options) => {
-  maxConcurrentReqs = _.get(options, 'maxConcurrentReqs', 1);
-  suspectFile = _.get(options, 'suspectFile', false);
-  return createLookupStream;
+module.exports = function(maxConcurrentReqs) {
+  return function(resolver) {
+    return createLookupStream(resolver, maxConcurrentReqs || 1);
+  };
 };

--- a/src/resolversFactory.js
+++ b/src/resolversFactory.js
@@ -1,4 +1,0 @@
-module.exports = {
-  createWofPipResolver: require('./httpPipResolver'),
-  createLocalPipResolver: require('./localPipResolver')
-};

--- a/test/configValidationTest.js
+++ b/test/configValidationTest.js
@@ -6,12 +6,12 @@ const configValidation = require('../src/configValidation');
 const proxyquire = require('proxyquire').noCallThru();
 
 tape('tests configuration scenarios', function(test) {
-  test.test('missing imports should not throw error', function(t) {
+  test.test('missing imports should throw error', function(t) {
     const config = {};
 
-    t.doesNotThrow(function() {
+    t.throws(function() {
       configValidation.validate(config);
-    });
+    }, /"imports" is required/);
     t.end();
 
   });
@@ -29,9 +29,38 @@ tape('tests configuration scenarios', function(test) {
 
   });
 
+  test.test('missing imports.whosonfirst should throw error', function(t) {
+    const config = {
+      imports: {}
+    };
+
+    t.throws(function() {
+      configValidation.validate(config);
+    }, /"whosonfirst" is required/);
+    t.end();
+
+  });
+
+  test.test('missing imports.whosonfirst.datapath should throw error', function(t) {
+    const config = {
+      imports: {
+        whosonfirst: {}
+      }
+    };
+
+    t.throws(function() {
+      configValidation.validate(config);
+    }, /"datapath" is required/);
+    t.end();
+
+  });
+
   test.test('missing imports.adminLookup should not throw error', function(t) {
     const config = {
       imports: {
+        whosonfirst: {
+          datapath: 'datapath value'
+        }
       }
     };
 
@@ -46,7 +75,10 @@ tape('tests configuration scenarios', function(test) {
     [null, 17, 'string', [], true].forEach((value) => {
       const config = {
         imports: {
-          adminLookup: value
+          adminLookup: value,
+          whosonfirst: {
+            datapath: 'datapath value'
+          }
         }
       };
 
@@ -65,6 +97,9 @@ tape('tests configuration scenarios', function(test) {
         imports: {
           adminLookup: {
             maxConcurrentReqs: value
+          },
+          whosonfirst: {
+            datapath: 'datapath value'
           }
         }
       };
@@ -84,6 +119,9 @@ tape('tests configuration scenarios', function(test) {
       imports: {
         adminLookup: {
           maxConcurrentReqs: 17.3
+        },
+        whosonfirst: {
+          datapath: 'datapath value'
         }
       }
     };
@@ -100,6 +138,9 @@ tape('tests configuration scenarios', function(test) {
     const config = {
       imports: {
         adminLookup: {
+        },
+        whosonfirst: {
+          datapath: 'datapath value'
         }
       }
     };
@@ -117,6 +158,9 @@ tape('tests configuration scenarios', function(test) {
       imports: {
         adminLookup: {
           maxConcurrentReqs: 17
+        },
+        whosonfirst: {
+          datapath: 'datapath value'
         }
       }
     };
@@ -129,14 +173,39 @@ tape('tests configuration scenarios', function(test) {
 
   });
 
+  test.test('non-string imports.whosonfirst.datapath should throw error', function(t) {
+    [null, 17, {}, [], true].forEach((value) => {
+      const config = {
+        imports: {
+          whosonfirst: {
+            datapath: value
+          }
+        }
+      };
+
+      t.throws(function() {
+        configValidation.validate(config);
+      }, /"datapath" must be a string/);
+    });
+
+    t.end();
+
+  });
+
   test.test('unknown properties should not throw errors', function(t) {
     const config = {
       imports: {
         adminLookup: {
           maxConcurrentReqs: 17,
           unknown_property: 'property value'
-        }
-      }
+        },
+        whosonfirst: {
+          datapath: 'datapath value',
+          unknown_property: 'property value'
+        },
+        unknown_property: 'property value'
+      },
+      unknown_property: 'property value'
     };
 
     t.doesNotThrow(function() {

--- a/test/configValidationTest.js
+++ b/test/configValidationTest.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const tape = require('tape');
+
+const configValidation = require('../src/configValidation');
+const proxyquire = require('proxyquire').noCallThru();
+
+tape('tests configuration scenarios', function(test) {
+  test.test('missing imports should not throw error', function(t) {
+    const config = {};
+
+    t.doesNotThrow(function() {
+      configValidation.validate(config);
+    });
+    t.end();
+
+  });
+
+  test.test('non-object imports should throw error', function(t) {
+    [null, 17, 'string', [], true].forEach((value) => {
+      const config = { imports: value };
+
+      t.throws(function() {
+        configValidation.validate(config);
+      }, /"imports" must be an object/);
+    });
+
+    t.end();
+
+  });
+
+  test.test('missing imports.adminLookup should not throw error', function(t) {
+    const config = {
+      imports: {
+      }
+    };
+
+    t.doesNotThrow(function() {
+      configValidation.validate(config);
+    });
+    t.end();
+
+  });
+
+  test.test('non-object imports.adminLookup should throw error', function(t) {
+    [null, 17, 'string', [], true].forEach((value) => {
+      const config = {
+        imports: {
+          adminLookup: value
+        }
+      };
+
+      t.throws(function() {
+        configValidation.validate(config);
+      }, /"adminLookup" must be an object/);
+    });
+
+    t.end();
+
+  });
+
+  test.test('non-number imports.adminLookup.maxConcurrentReqs should throw error', function(t) {
+    [null, 'string', {}, [], true].forEach((value) => {
+      const config = {
+        imports: {
+          adminLookup: {
+            maxConcurrentReqs: value
+          }
+        }
+      };
+
+      t.throws(function() {
+        configValidation.validate(config);
+      }, /"maxConcurrentReqs" must be a number/);
+
+    });
+
+    t.end();
+
+  });
+
+  test.test('non-integer imports.adminLookup.maxConcurrentReqs should throw error', function(t) {
+    const config = {
+      imports: {
+        adminLookup: {
+          maxConcurrentReqs: 17.3
+        }
+      }
+    };
+
+    t.throws(function() {
+      configValidation.validate(config);
+    }, /"maxConcurrentReqs" must be an integer/);
+
+    t.end();
+
+  });
+
+  test.test('missing imports.adminLookup.maxConcurrentReqs should not throw error', function(t) {
+    const config = {
+      imports: {
+        adminLookup: {
+        }
+      }
+    };
+
+    t.doesNotThrow(function() {
+      configValidation.validate(config);
+    });
+
+    t.end();
+
+  });
+
+  test.test('integer imports.adminLookup.maxConcurrentReqs should not throw error', function(t) {
+    const config = {
+      imports: {
+        adminLookup: {
+          maxConcurrentReqs: 17
+        }
+      }
+    };
+
+    t.doesNotThrow(function() {
+      configValidation.validate(config);
+    });
+
+    t.end();
+
+  });
+
+  test.test('unknown properties should not throw errors', function(t) {
+    const config = {
+      imports: {
+        adminLookup: {
+          maxConcurrentReqs: 17,
+          unknown_property: 'property value'
+        }
+      }
+    };
+
+    t.doesNotThrow(function() {
+      configValidation.validate(config);
+    });
+
+    t.end();
+
+  });
+
+});
+
+tape('tests for main entry point', function(test) {
+  test.test('configValidation throwing error should rethrow', function(t) {
+    const config = {};
+
+    t.throws(function() {
+      proxyquire('../index', {
+        './src/configValidation': {
+          validate: () => {
+            throw Error('config is not valid');
+          }
+        }
+      });
+
+      configValidation.validate(config);
+    }, /config is not valid/);
+    t.end();
+
+  });
+});

--- a/test/httpPipResolverTest.js
+++ b/test/httpPipResolverTest.js
@@ -2,7 +2,7 @@ var tape = require('tape');
 var http = require('http');
 var intercept = require('intercept-stdout');
 
-var httpPipResolver = require('../src/httpPipResolver')({ maxConcurrentReqs: 1 });
+var httpPipResolver = require('../src/httpPipResolver')(1);
 
 tape('tests', function(test) {
   test.test('return value should be parsed from server response', function(t) {

--- a/test/httpPipResolverTest.js
+++ b/test/httpPipResolverTest.js
@@ -2,7 +2,7 @@ var tape = require('tape');
 var http = require('http');
 var intercept = require('intercept-stdout');
 
-var resolvers = require('../src/resolversFactory');
+var httpPipResolver = require('../src/httpPipResolver')({ maxConcurrentReqs: 1 });
 
 tape('tests', function(test) {
   test.test('return value should be parsed from server response', function(t) {
@@ -85,7 +85,7 @@ tape('tests', function(test) {
 
     server.listen(0);
 
-    var resolver = resolvers.createWofPipResolver('http://localhost:' + server.address().port + '/?');
+    var resolver = httpPipResolver('http://localhost:' + server.address().port + '/?');
 
     var centroid = {
       lat: 12.121212,
@@ -161,7 +161,7 @@ tape('tests', function(test) {
 
     server.listen(0);
 
-    var resolver = resolvers.createWofPipResolver('localhost:' + server.address().port + '/?');
+    var resolver = httpPipResolver('localhost:' + server.address().port + '/?');
 
     var centroid = {
       lat: 12.121212,
@@ -199,7 +199,7 @@ tape('tests', function(test) {
   });
 
   test.test('error condition', function(t) {
-    var resolver = resolvers.createWofPipResolver('http://localhost:12345/?');
+    var resolver = httpPipResolver('http://localhost:12345/?');
 
     var centroid = {
       lat: 12.121212,
@@ -236,7 +236,7 @@ tape('tests', function(test) {
 
     server.listen(0);
 
-    var resolver = resolvers.createWofPipResolver('http://localhost:' + server.address().port + '/?');
+    var resolver = httpPipResolver('http://localhost:' + server.address().port + '/?');
 
     var centroid = {
       lat: 12.121212,

--- a/test/localPipResolverTest.js
+++ b/test/localPipResolverTest.js
@@ -1,6 +1,6 @@
 var tape = require('tape');
 
-var resolvers = require('../src/resolversFactory');
+var localPipResolver = require('../src/localPipResolver');
 
 tape('tests', function(test) {
 
@@ -47,7 +47,7 @@ tape('tests', function(test) {
 
     var lookupServiceMock = makeLookupMock(t, expectedLookupParams, null, results);
 
-    var resolver = resolvers.createLocalPipResolver(lookupServiceMock);
+    var resolver = localPipResolver()(lookupServiceMock);
 
     var callback = function(err, result) {
       var expected = {

--- a/test/lookupStreamTest.js
+++ b/test/lookupStreamTest.js
@@ -3,7 +3,7 @@ var event_stream = require('event-stream');
 var Document = require('pelias-model').Document;
 var _ = require('lodash');
 
-var stream = require('../src/lookupStream');
+var stream = require('../src/lookupStream')();
 
 function test_stream(input, testedStream, callback) {
     var input_stream = event_stream.readArray(input);
@@ -14,11 +14,17 @@ function test_stream(input, testedStream, callback) {
 
 tape('tests', function(test) {
   test.test('doc without centroid should not modify input', function(t) {
-    var input = [
+    const input = [
       new Document( 'whosonfirst', 'placetype', '1')
     ];
 
-    var lookupStream = stream.createLookupStream({});
+    const resolver = {
+      lookup: () => {
+        throw new Error('lookup should not have been called');
+      }
+    };
+
+    const lookupStream = stream(resolver);
 
     test_stream(input, lookupStream, function(err, actual) {
       t.deepEqual(actual, input, 'nothing should have changed');
@@ -93,7 +99,7 @@ tape('tests', function(test) {
       }
     };
 
-    var lookupStream = stream.createLookupStream(resolver);
+    var lookupStream = stream(resolver);
 
     test_stream(input, lookupStream, function(err, actual) {
       t.deepEqual(actual, expected, 'all fields should have been set');
@@ -129,7 +135,7 @@ tape('tests', function(test) {
       }
     };
 
-    var lookupStream = stream.createLookupStream(resolver);
+    var lookupStream = stream(resolver);
 
     test_stream(input, lookupStream, function(err, actual) {
       t.deepEqual(actual, expected, 'result with missing fields should not set anything in doc');
@@ -151,10 +157,7 @@ tape('tests', function(test) {
       }
     };
 
-    var config = {
-      imports: { adminLookup: { maxConcurrentReqs: 1 } }
-    };
-    var lookupStream = stream.createLookupStream(resolver, config);
+    var lookupStream = stream(resolver);
 
     var input_stream = event_stream.readArray([input]);
     var destination_stream = event_stream.writeArray(function() {
@@ -198,7 +201,7 @@ tape('tests', function(test) {
       }
     };
 
-    var lookupStream = stream.createLookupStream(resolver);
+    var lookupStream = stream(resolver);
 
     test_stream(input, lookupStream, function(err, actual) {
       t.deepEqual(actual, expected, 'region abbreviation should have been set');
@@ -235,7 +238,7 @@ tape('tests', function(test) {
       }
     };
 
-    var lookupStream = stream.createLookupStream(resolver);
+    var lookupStream = stream(resolver);
 
     test_stream(input, lookupStream, function(err, actual) {
       t.deepEqual(actual, expected, 'no region abbreviation should have been set');
@@ -271,7 +274,7 @@ tape('tests', function(test) {
       }
     };
 
-    var lookupStream = stream.createLookupStream(resolver);
+    var lookupStream = stream(resolver);
 
     test_stream(input, lookupStream, function(err, actual) {
       t.deepEqual(actual, expected, 'no region abbreviation should have been set');
@@ -300,7 +303,7 @@ tape('tests', function(test) {
       }
     };
 
-    var lookupStream = stream.createLookupStream(resolver);
+    var lookupStream = stream(resolver);
 
     test_stream([inputDoc], lookupStream, function(err, actual) {
       t.deepEqual(actual, [expectedDoc], 'no region abbreviation should have been set');
@@ -330,7 +333,7 @@ tape('tests', function(test) {
       }
     };
 
-    var lookupStream = stream.createLookupStream(resolver);
+    var lookupStream = stream(resolver);
 
     test_stream([inputDoc], lookupStream, function(err, actual) {
       t.deepEqual(actual, [expectedDoc], 'alpha3 should have been set');
@@ -363,7 +366,7 @@ tape('tests', function(test) {
       }
     };
 
-    var lookupStream = stream.createLookupStream(resolver);
+    var lookupStream = stream(resolver);
 
     t.doesNotThrow( function () {
 
@@ -399,7 +402,7 @@ tape('tests', function(test) {
       }
     };
 
-    var lookupStream = stream.createLookupStream(resolver);
+    var lookupStream = stream(resolver);
 
     test_stream(input, lookupStream, function(err, actual) {
       t.deepEqual(actual, expected, 'all fields should have been set');
@@ -436,7 +439,7 @@ tape('tests', function(test) {
       }
     };
 
-    var lookupStream = stream.createLookupStream(resolver);
+    var lookupStream = stream(resolver);
 
     test_stream(input, lookupStream, function(err, actual) {
       t.deepEqual(actual, expected, 'all fields should have been set');
@@ -456,7 +459,7 @@ tape('tests', function(test) {
       }
     };
 
-    var lookupStream = stream.createLookupStream(resolver);
+    var lookupStream = stream(resolver);
     lookupStream.end();
 
   });

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
 require ('./configValidationTest.js');
 require ('./lookupStreamTest.js');
-require ('./resolversFactoryTest.js');
-require ('./resolversFactoryLocalTest.js');
+require ('./httpPipResolverTest.js');
+require ('./localPipResolverTest.js');

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+require ('./configValidationTest.js');
 require ('./lookupStreamTest.js');
 require ('./resolversFactoryTest.js');
 require ('./resolversFactoryLocalTest.js');


### PR DESCRIPTION
We should discuss this.  The tradition has been to put configValidation in the main entry point so the module can't even be loaded if the configuration is invalid, that doesn't work the same way in this module since pelias config can be passed to the individual create functions.  We should probably go with dependency injection so to the create function gets only what it needs instead of hosting the entire pelias config internally.