### PR TITLE
removed support for `disputed` place type

### DIFF
--- a/actualTestResults.json
+++ b/actualTestResults.json
@@ -13,20 +13,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -40,7 +33,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -52,6 +68,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -70,20 +91,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -97,7 +111,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -109,6 +146,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -127,20 +169,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -154,7 +189,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -166,6 +224,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -184,20 +247,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -211,7 +267,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -223,6 +302,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -241,20 +325,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -268,7 +345,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -280,6 +380,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -298,20 +403,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -325,7 +423,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -337,6 +458,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -355,20 +481,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -382,7 +501,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -394,6 +536,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -412,20 +559,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -439,7 +579,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -451,6 +614,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -469,20 +637,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -496,7 +657,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -508,6 +692,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -526,20 +715,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -553,7 +735,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -565,6 +770,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -583,20 +793,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -610,7 +813,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -622,6 +848,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -640,20 +871,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -667,7 +891,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -679,6 +926,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -697,20 +949,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -724,7 +969,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -736,6 +1004,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -754,20 +1027,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -781,7 +1047,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -793,6 +1082,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -811,20 +1105,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -838,7 +1125,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -850,6 +1160,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -868,20 +1183,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -895,7 +1203,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -907,6 +1238,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -925,20 +1261,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -952,7 +1281,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -964,6 +1316,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -982,20 +1339,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -1009,7 +1359,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1021,6 +1394,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1039,20 +1417,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -1066,7 +1437,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1078,6 +1472,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1096,20 +1495,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -1123,7 +1515,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1135,6 +1550,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1153,20 +1573,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -1180,7 +1593,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1192,6 +1628,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1210,20 +1651,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -1237,7 +1671,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1249,6 +1706,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1267,20 +1729,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -1294,7 +1749,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1306,6 +1784,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1324,20 +1807,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -1351,7 +1827,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1363,6 +1862,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1381,20 +1885,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -1408,7 +1905,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1420,6 +1940,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1438,20 +1963,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -1465,7 +1983,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1477,6 +2018,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1495,20 +2041,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -1522,7 +2061,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1534,6 +2096,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1552,20 +2119,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -1579,7 +2139,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1591,6 +2174,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1609,20 +2197,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -1636,7 +2217,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1648,6 +2252,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1666,20 +2275,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -1693,7 +2295,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1705,6 +2330,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1723,20 +2353,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -1750,7 +2373,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1762,6 +2408,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1780,20 +2431,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -1807,7 +2451,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1819,6 +2486,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1837,20 +2509,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -1864,7 +2529,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1876,6 +2564,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1894,20 +2587,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -1921,7 +2607,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1933,6 +2642,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -1951,20 +2665,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -1978,7 +2685,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -1990,6 +2720,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2008,20 +2743,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -2035,7 +2763,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2047,6 +2798,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2065,20 +2821,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -2092,7 +2841,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2104,6 +2876,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2122,20 +2899,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -2149,7 +2919,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2161,6 +2954,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2179,20 +2977,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -2206,7 +2997,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2218,6 +3032,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2236,20 +3055,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -2263,7 +3075,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2275,6 +3110,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2293,20 +3133,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -2320,7 +3153,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2332,6 +3188,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2350,20 +3211,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -2377,7 +3231,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2389,6 +3266,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2407,20 +3289,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -2434,7 +3309,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2446,6 +3344,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2464,20 +3367,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -2491,7 +3387,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2503,6 +3422,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2521,20 +3445,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -2548,7 +3465,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2560,6 +3500,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2578,20 +3523,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -2605,7 +3543,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2617,6 +3578,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2635,20 +3601,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -2662,7 +3621,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2674,6 +3656,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2692,20 +3679,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -2719,7 +3699,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2731,6 +3734,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2749,20 +3757,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -2776,7 +3777,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2788,6 +3812,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2806,20 +3835,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -2833,7 +3855,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2845,6 +3890,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2863,20 +3913,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -2890,7 +3933,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2902,6 +3968,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2920,20 +3991,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -2947,7 +4011,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -2959,6 +4046,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -2977,20 +4069,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3004,7 +4089,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3016,6 +4124,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3034,20 +4147,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3061,7 +4167,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3073,6 +4202,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3091,20 +4225,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3118,7 +4245,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3130,6 +4280,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3148,20 +4303,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3175,7 +4323,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3187,6 +4358,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3205,20 +4381,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3232,7 +4401,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3244,6 +4436,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3262,20 +4459,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3289,7 +4479,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3301,6 +4514,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3319,20 +4537,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3346,7 +4557,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3358,6 +4592,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3376,20 +4615,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3403,7 +4635,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3415,6 +4670,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3433,20 +4693,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3460,7 +4713,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3472,6 +4748,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3490,20 +4771,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3517,7 +4791,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3529,6 +4826,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3547,20 +4849,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3574,7 +4869,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3586,6 +4904,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3604,20 +4927,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -3631,7 +4947,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3643,6 +4982,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3661,20 +5005,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -3688,7 +5025,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3700,6 +5060,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3718,20 +5083,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -3745,7 +5103,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3757,6 +5138,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3775,20 +5161,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -3802,7 +5181,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3814,6 +5216,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3832,20 +5239,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -3859,7 +5259,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3871,6 +5294,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3889,20 +5317,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -3916,7 +5337,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3928,6 +5372,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -3946,20 +5395,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -3973,7 +5415,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -3985,6 +5450,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4003,20 +5473,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -4030,7 +5493,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4042,6 +5528,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4060,20 +5551,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -4087,7 +5571,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4099,6 +5606,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4117,20 +5629,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -4144,7 +5649,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4156,6 +5684,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4174,20 +5707,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -4201,7 +5727,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4213,6 +5762,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4231,20 +5785,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -4258,7 +5805,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4270,6 +5840,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4288,20 +5863,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -4315,7 +5883,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4327,6 +5918,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4345,20 +5941,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -4372,7 +5961,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4384,6 +5996,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4402,20 +6019,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -4429,7 +6039,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4441,6 +6074,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4459,20 +6097,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -4486,7 +6117,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4498,6 +6152,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4516,20 +6175,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -4543,7 +6195,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4555,6 +6230,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4573,20 +6253,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -4600,7 +6273,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4612,6 +6308,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4630,20 +6331,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -4657,7 +6351,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4669,6 +6386,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4687,20 +6409,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -4714,7 +6429,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4726,6 +6464,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4744,20 +6487,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -4771,7 +6507,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4783,6 +6542,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4801,20 +6565,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -4828,7 +6585,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4840,6 +6620,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4858,20 +6643,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -4885,7 +6663,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4897,6 +6698,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4915,20 +6721,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -4942,7 +6741,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -4954,6 +6776,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -4972,20 +6799,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -4999,7 +6819,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5011,6 +6854,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5029,20 +6877,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -5056,7 +6897,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5068,6 +6932,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5086,20 +6955,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -5113,7 +6975,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5125,6 +7010,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5143,20 +7033,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -5170,7 +7053,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5182,6 +7088,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5200,20 +7111,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -5227,7 +7131,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5239,6 +7166,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5257,20 +7189,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -5284,7 +7209,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5296,6 +7244,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5314,20 +7267,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -5341,7 +7287,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5353,6 +7322,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5371,20 +7345,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -5398,7 +7365,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5410,6 +7400,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5428,20 +7423,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -5455,7 +7443,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5467,6 +7478,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5485,20 +7501,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -5512,7 +7521,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5524,6 +7556,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5542,20 +7579,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -5569,7 +7599,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5581,6 +7634,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5599,20 +7657,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -5626,7 +7677,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5638,6 +7712,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5656,20 +7735,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -5683,7 +7755,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5695,6 +7790,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5713,20 +7813,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -5740,7 +7833,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5752,6 +7868,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5770,20 +7891,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -5797,7 +7911,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5809,6 +7946,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5827,20 +7969,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -5854,7 +7989,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5866,6 +8024,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5884,20 +8047,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -5911,7 +8067,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5923,6 +8102,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5941,20 +8125,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -5968,7 +8145,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -5980,6 +8180,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -5998,20 +8203,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -6025,7 +8223,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6037,6 +8258,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6055,20 +8281,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -6082,7 +8301,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6094,6 +8336,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6112,20 +8359,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -6139,7 +8379,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6151,6 +8414,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6169,20 +8437,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -6196,7 +8457,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6208,6 +8492,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6226,20 +8515,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -6253,7 +8535,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6265,6 +8570,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6283,20 +8593,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -6310,7 +8613,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6322,6 +8648,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6340,20 +8671,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -6367,7 +8691,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6379,6 +8726,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6397,20 +8749,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -6424,7 +8769,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6436,6 +8804,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6454,20 +8827,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -6481,7 +8847,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6493,6 +8882,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6511,20 +8905,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -6538,7 +8925,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6550,6 +8960,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6568,20 +8983,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -6595,7 +9003,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6607,6 +9038,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6625,20 +9061,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -6652,7 +9081,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6664,6 +9116,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6682,20 +9139,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -6709,7 +9159,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6721,6 +9194,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6739,20 +9217,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -6766,7 +9237,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6778,6 +9272,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6796,20 +9295,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -6823,7 +9315,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6835,6 +9350,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6853,20 +9373,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -6880,7 +9393,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6892,6 +9428,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6910,20 +9451,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -6937,7 +9471,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -6949,6 +9506,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -6967,20 +9529,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -6994,7 +9549,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7006,6 +9584,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7024,20 +9607,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -7051,7 +9627,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7063,6 +9662,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7081,20 +9685,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -7108,7 +9705,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7120,6 +9740,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7138,20 +9763,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -7165,7 +9783,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7177,6 +9818,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7195,20 +9841,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -7222,7 +9861,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7234,6 +9896,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7252,20 +9919,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -7279,7 +9939,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7291,6 +9974,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7309,20 +9997,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7336,7 +10017,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7348,6 +10052,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7366,20 +10075,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7393,7 +10095,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7405,6 +10130,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7423,20 +10153,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7450,7 +10173,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7462,6 +10208,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7480,20 +10231,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7507,7 +10251,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7519,6 +10286,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7537,20 +10309,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7564,7 +10329,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7576,6 +10364,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7594,20 +10387,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7621,7 +10407,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7633,6 +10442,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7651,20 +10465,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7678,7 +10485,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7690,6 +10520,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7708,20 +10543,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7735,7 +10563,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7747,6 +10598,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7765,20 +10621,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7792,7 +10641,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7804,6 +10676,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7822,20 +10699,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7849,7 +10719,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7861,6 +10754,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7879,20 +10777,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7906,7 +10797,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7918,6 +10832,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7936,20 +10855,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -7963,7 +10875,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -7975,6 +10910,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -7993,20 +10933,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -8020,7 +10953,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8032,6 +10988,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8050,20 +11011,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -8077,7 +11031,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8089,6 +11066,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8107,20 +11089,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -8134,7 +11109,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8146,6 +11144,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8164,20 +11167,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -8191,7 +11187,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8203,6 +11222,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8221,20 +11245,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8248,7 +11265,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8260,6 +11300,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8278,20 +11323,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8305,7 +11343,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8317,6 +11378,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8335,20 +11401,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8362,7 +11421,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8374,6 +11456,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8392,20 +11479,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8419,7 +11499,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8431,6 +11534,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8449,20 +11557,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8476,7 +11577,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8488,6 +11612,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8506,20 +11635,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8533,7 +11655,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8545,6 +11690,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8563,20 +11713,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8590,7 +11733,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8602,6 +11768,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8620,20 +11791,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8647,7 +11811,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8659,6 +11846,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8677,20 +11869,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8704,7 +11889,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8716,6 +11924,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8734,20 +11947,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8761,7 +11967,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8773,6 +12002,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8791,20 +12025,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8818,7 +12045,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8830,6 +12080,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8848,20 +12103,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8875,7 +12123,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8887,6 +12158,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8905,20 +12181,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8932,7 +12201,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -8944,6 +12236,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -8962,20 +12259,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -8989,7 +12279,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9001,6 +12314,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9019,20 +12337,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -9046,7 +12357,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9058,6 +12392,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9076,20 +12415,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -9103,7 +12435,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9115,6 +12470,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9133,20 +12493,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -9160,7 +12513,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9172,6 +12548,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9190,20 +12571,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -9217,7 +12591,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9229,6 +12626,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9247,20 +12649,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -9274,7 +12669,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9286,6 +12704,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9304,20 +12727,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -9331,7 +12747,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9343,6 +12782,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9361,20 +12805,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -9388,7 +12825,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9400,6 +12860,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9418,20 +12883,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -9445,7 +12903,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9457,6 +12938,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9475,20 +12961,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -9502,7 +12981,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9514,6 +13016,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9532,20 +13039,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -9559,7 +13059,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9571,6 +13094,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9589,20 +13117,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -9616,7 +13137,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9628,6 +13172,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9646,20 +13195,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -9673,7 +13215,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9685,6 +13250,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9703,20 +13273,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -9730,7 +13293,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9742,6 +13328,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9760,20 +13351,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -9787,7 +13371,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9799,6 +13406,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9817,20 +13429,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -9844,7 +13449,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9856,6 +13484,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9874,20 +13507,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -9901,7 +13527,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9913,6 +13562,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9931,20 +13585,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -9958,7 +13605,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -9970,6 +13640,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -9988,20 +13663,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -10015,7 +13683,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10027,6 +13718,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10045,20 +13741,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10072,7 +13761,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10084,6 +13796,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10102,20 +13819,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10129,7 +13839,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10141,6 +13874,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10159,20 +13897,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10186,7 +13917,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10198,6 +13952,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10216,20 +13975,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10243,7 +13995,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10255,6 +14030,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10273,20 +14053,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10300,7 +14073,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10312,6 +14108,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10330,20 +14131,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10357,7 +14151,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10369,6 +14186,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10387,20 +14209,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10414,7 +14229,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10426,6 +14264,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10444,20 +14287,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10471,7 +14307,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10483,6 +14342,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10501,20 +14365,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10528,7 +14385,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10540,6 +14420,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10558,20 +14443,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10585,7 +14463,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10597,6 +14498,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10615,20 +14521,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10642,7 +14541,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10654,6 +14576,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10672,20 +14599,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10699,7 +14619,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10711,6 +14654,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10729,20 +14677,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -10756,7 +14697,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10768,6 +14732,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10786,20 +14755,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -10813,7 +14775,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10825,6 +14810,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10843,20 +14833,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -10870,7 +14853,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10882,6 +14888,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10900,20 +14911,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -10927,7 +14931,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10939,6 +14966,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -10957,20 +14989,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -10984,7 +15009,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -10996,6 +15044,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11014,20 +15067,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11041,7 +15087,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11053,6 +15122,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11071,20 +15145,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11098,7 +15165,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11110,6 +15200,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11128,20 +15223,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11155,7 +15243,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11167,6 +15278,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11185,20 +15301,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11212,7 +15321,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11224,6 +15356,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11242,20 +15379,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11269,7 +15399,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11281,6 +15434,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11299,20 +15457,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11326,7 +15477,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11338,6 +15512,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11356,20 +15535,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11383,7 +15555,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11395,6 +15590,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11413,20 +15613,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11440,7 +15633,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11452,6 +15668,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11470,20 +15691,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11497,7 +15711,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11509,6 +15746,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11527,20 +15769,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11554,7 +15789,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11566,6 +15824,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11584,20 +15847,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11611,7 +15867,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11623,6 +15902,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11641,20 +15925,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11668,7 +15945,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11680,6 +15980,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11698,20 +16003,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11725,7 +16023,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11737,6 +16058,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11755,20 +16081,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11782,7 +16101,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11794,6 +16136,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11812,20 +16159,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -11839,7 +16179,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11851,6 +16214,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11869,20 +16237,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -11896,7 +16257,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11908,6 +16292,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11926,20 +16315,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -11953,7 +16335,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -11965,6 +16370,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -11983,20 +16393,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -12010,7 +16413,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12022,6 +16448,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12040,20 +16471,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -12067,7 +16491,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12079,6 +16526,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12097,20 +16549,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -12124,7 +16569,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12136,6 +16604,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12154,20 +16627,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -12181,7 +16647,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12193,6 +16682,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12211,20 +16705,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -12238,7 +16725,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12250,6 +16760,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12268,20 +16783,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -12295,7 +16803,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12307,6 +16838,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12325,20 +16861,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -12352,7 +16881,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12364,6 +16916,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12382,20 +16939,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -12409,7 +16959,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12421,6 +16994,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12439,20 +17017,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -12466,7 +17037,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12478,6 +17072,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12496,20 +17095,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -12523,7 +17115,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12535,6 +17150,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12553,20 +17173,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -12580,7 +17193,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12592,6 +17228,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12610,20 +17251,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -12637,7 +17271,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12649,6 +17306,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12667,20 +17329,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -12694,7 +17349,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12706,6 +17384,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12724,20 +17407,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -12751,7 +17427,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12763,6 +17462,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12781,20 +17485,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -12808,7 +17505,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12820,6 +17540,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12838,20 +17563,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -12865,7 +17583,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12877,6 +17618,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12895,20 +17641,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -12922,7 +17661,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12934,6 +17696,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -12952,20 +17719,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -12979,7 +17739,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -12991,6 +17774,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13009,20 +17797,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -13036,7 +17817,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13048,6 +17852,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13066,20 +17875,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -13093,7 +17895,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13105,6 +17930,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13123,20 +17953,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -13150,7 +17973,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13162,6 +18008,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13180,20 +18031,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -13207,7 +18051,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13219,6 +18086,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13237,20 +18109,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -13264,7 +18129,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13276,6 +18164,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13294,20 +18187,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -13321,7 +18207,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13333,6 +18242,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13351,20 +18265,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -13378,7 +18285,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13390,6 +18320,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13408,20 +18343,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -13435,7 +18363,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13447,6 +18398,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13465,20 +18421,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -13492,7 +18441,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13504,6 +18476,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13522,20 +18499,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -13549,7 +18519,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13561,6 +18554,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13579,20 +18577,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -13606,7 +18597,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13618,6 +18632,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13636,20 +18655,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -13663,7 +18675,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13675,6 +18710,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13693,20 +18733,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -13720,7 +18753,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13732,6 +18788,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13750,20 +18811,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -13777,7 +18831,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13789,6 +18866,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13807,20 +18889,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -13834,7 +18909,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13846,6 +18944,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13864,20 +18967,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -13891,7 +18987,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13903,6 +19022,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13921,20 +19045,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -13948,7 +19065,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -13960,6 +19100,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -13978,20 +19123,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -14005,7 +19143,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14017,6 +19178,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14035,20 +19201,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -14062,7 +19221,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14074,6 +19256,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14092,20 +19279,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -14119,7 +19299,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14131,6 +19334,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14149,20 +19357,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -14176,7 +19377,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14188,6 +19412,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14206,20 +19435,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -14233,7 +19455,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14245,6 +19490,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14263,20 +19513,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -14290,7 +19533,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14302,6 +19568,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14320,20 +19591,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -14347,7 +19611,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14359,6 +19646,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14377,20 +19669,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -14404,7 +19689,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14416,6 +19724,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14434,20 +19747,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -14461,7 +19767,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14473,6 +19802,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14491,20 +19825,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -14518,7 +19845,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14530,6 +19880,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14548,20 +19903,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -14575,7 +19923,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14587,6 +19958,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14605,20 +19981,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -14632,7 +20001,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14644,6 +20036,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14662,20 +20059,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -14689,7 +20079,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14701,6 +20114,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14719,20 +20137,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -14746,7 +20157,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14758,6 +20192,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14776,20 +20215,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -14803,7 +20235,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14815,6 +20270,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14833,20 +20293,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -14860,7 +20313,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14872,6 +20348,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14890,20 +20371,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -14917,7 +20391,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14929,6 +20426,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -14947,20 +20449,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -14974,7 +20469,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -14986,6 +20504,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15004,20 +20527,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -15031,7 +20547,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15043,6 +20582,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15061,20 +20605,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -15088,7 +20625,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15100,6 +20660,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15118,20 +20683,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -15145,7 +20703,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15157,6 +20738,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15175,20 +20761,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -15202,7 +20781,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15214,6 +20816,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15232,20 +20839,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -15259,7 +20859,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15271,6 +20894,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15289,20 +20917,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -15316,7 +20937,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15328,6 +20972,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15346,20 +20995,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -15373,7 +21015,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15385,6 +21050,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15403,20 +21073,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -15430,7 +21093,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15442,6 +21128,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15460,20 +21151,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -15487,7 +21171,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15499,6 +21206,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15517,20 +21229,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -15544,7 +21249,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15556,6 +21284,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15574,20 +21307,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -15601,7 +21327,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15613,6 +21362,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15631,20 +21385,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -15658,7 +21405,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15670,6 +21440,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15688,20 +21463,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -15715,7 +21483,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15727,6 +21518,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15745,20 +21541,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -15772,7 +21561,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15784,6 +21596,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15802,20 +21619,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -15829,7 +21639,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15841,6 +21674,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15859,20 +21697,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -15886,7 +21717,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15898,6 +21752,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15916,20 +21775,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -15943,7 +21795,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -15955,6 +21830,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -15973,20 +21853,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -16000,7 +21873,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16012,6 +21908,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16030,20 +21931,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -16057,7 +21951,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16069,6 +21986,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16087,20 +22009,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -16114,7 +22029,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16126,6 +22064,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16144,20 +22087,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -16171,7 +22107,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16183,6 +22142,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16201,20 +22165,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -16228,7 +22185,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16240,6 +22220,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16258,20 +22243,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -16285,7 +22263,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16297,6 +22298,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16315,20 +22321,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -16342,7 +22341,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16354,6 +22376,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16372,20 +22399,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -16399,7 +22419,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16411,6 +22454,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16429,20 +22477,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -16456,7 +22497,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16468,6 +22532,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16486,20 +22555,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -16513,7 +22575,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16525,6 +22610,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16543,20 +22633,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -16570,7 +22653,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16582,6 +22688,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16600,20 +22711,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -16627,7 +22731,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16639,6 +22766,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16657,20 +22789,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -16684,7 +22809,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16696,6 +22844,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16714,20 +22867,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -16741,7 +22887,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16753,6 +22922,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16771,20 +22945,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -16798,7 +22965,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16810,6 +23000,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16828,20 +23023,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -16855,7 +23043,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16867,6 +23078,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16885,20 +23101,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -16912,7 +23121,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16924,6 +23156,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16942,20 +23179,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -16969,7 +23199,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -16981,6 +23234,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -16999,20 +23257,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -17026,7 +23277,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17038,6 +23312,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17056,20 +23335,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -17083,7 +23355,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17095,6 +23390,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17113,20 +23413,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -17140,7 +23433,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17152,6 +23468,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17170,20 +23491,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -17197,7 +23511,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17209,6 +23546,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17227,20 +23569,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -17254,7 +23589,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17266,6 +23624,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17284,20 +23647,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -17311,7 +23667,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17323,6 +23702,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17341,20 +23725,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -17368,7 +23745,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17380,6 +23780,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17398,20 +23803,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -17425,7 +23823,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17437,6 +23858,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17455,20 +23881,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -17482,7 +23901,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17494,6 +23936,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17512,20 +23959,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -17539,7 +23979,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17551,6 +24014,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17569,20 +24037,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -17596,7 +24057,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17608,6 +24092,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17626,20 +24115,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -17653,7 +24135,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17665,6 +24170,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17683,20 +24193,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -17710,7 +24213,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17722,6 +24248,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17740,20 +24271,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -17767,7 +24291,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17779,6 +24326,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17797,20 +24349,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -17824,7 +24369,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17836,6 +24404,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17854,20 +24427,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -17881,7 +24447,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17893,6 +24482,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17911,20 +24505,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -17938,7 +24525,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -17950,6 +24560,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -17968,20 +24583,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -17995,7 +24603,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18007,6 +24638,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18025,20 +24661,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -18052,7 +24681,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18064,6 +24716,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18082,20 +24739,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -18109,7 +24759,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18121,6 +24794,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18139,20 +24817,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -18166,7 +24837,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18178,6 +24872,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18196,20 +24895,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -18223,7 +24915,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18235,6 +24950,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18253,20 +24973,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18280,7 +24993,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18292,6 +25028,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18310,20 +25051,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18337,7 +25071,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18349,6 +25106,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18367,20 +25129,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18394,7 +25149,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18406,6 +25184,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18424,20 +25207,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18451,7 +25227,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18463,6 +25262,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18481,20 +25285,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18508,7 +25305,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18520,6 +25340,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18538,20 +25363,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18565,7 +25383,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18577,6 +25418,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18595,20 +25441,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18622,7 +25461,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18634,6 +25496,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18652,20 +25519,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18679,7 +25539,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18691,6 +25574,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18709,20 +25597,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18736,7 +25617,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18748,6 +25652,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18766,20 +25675,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18793,7 +25695,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18805,6 +25730,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18823,20 +25753,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18850,7 +25773,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18862,6 +25808,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18880,20 +25831,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18907,7 +25851,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18919,6 +25886,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18937,20 +25909,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -18964,7 +25929,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -18976,6 +25964,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -18994,20 +25987,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -19021,7 +26007,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19033,6 +26042,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19051,20 +26065,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -19078,7 +26085,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19090,6 +26120,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19108,20 +26143,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -19135,7 +26163,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19147,6 +26198,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19165,20 +26221,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19192,7 +26241,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19204,6 +26276,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19222,20 +26299,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19249,7 +26319,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19261,6 +26354,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19279,20 +26377,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19306,7 +26397,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19318,6 +26432,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19336,20 +26455,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19363,7 +26475,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19375,6 +26510,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19393,20 +26533,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19420,7 +26553,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19432,6 +26588,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19450,20 +26611,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19477,7 +26631,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19489,6 +26666,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19507,20 +26689,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19534,7 +26709,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19546,6 +26744,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19564,20 +26767,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19591,7 +26787,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19603,6 +26822,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19621,20 +26845,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19648,7 +26865,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19660,6 +26900,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19678,20 +26923,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19705,7 +26943,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19717,6 +26978,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19735,20 +27001,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19762,7 +27021,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19774,6 +27056,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19792,20 +27079,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19819,7 +27099,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19831,6 +27134,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19849,20 +27157,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19876,7 +27177,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19888,6 +27212,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19906,20 +27235,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19933,7 +27255,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -19945,6 +27290,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -19963,20 +27313,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -19990,7 +27333,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20002,6 +27368,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20020,20 +27391,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -20047,7 +27411,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20059,6 +27446,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20077,20 +27469,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -20104,7 +27489,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20116,6 +27524,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20134,20 +27547,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -20161,7 +27567,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20173,6 +27602,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20191,20 +27625,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -20218,7 +27645,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20230,6 +27680,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20248,20 +27703,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -20275,7 +27723,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20287,6 +27758,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20305,20 +27781,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -20332,7 +27801,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20344,6 +27836,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20362,20 +27859,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -20389,7 +27879,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20401,6 +27914,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20419,20 +27937,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -20446,7 +27957,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20458,6 +27992,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20476,20 +28015,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -20503,7 +28035,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20515,6 +28070,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20533,20 +28093,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -20560,7 +28113,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20572,6 +28148,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20590,20 +28171,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -20617,7 +28191,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20629,6 +28226,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20647,20 +28249,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -20674,7 +28269,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20686,6 +28304,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20704,20 +28327,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -20731,7 +28347,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20743,6 +28382,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20761,20 +28405,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -20788,7 +28425,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20800,6 +28460,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20818,20 +28483,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -20845,7 +28503,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20857,6 +28538,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20875,20 +28561,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -20902,7 +28581,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20914,6 +28616,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20932,20 +28639,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866533,
@@ -20959,7 +28659,30 @@
             "neighbourhood_id": 85866533,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.273991,
+          "lon": -123.120091
+        },
+        "BoundingBox": "-123.132019043,49.2652621401,-123.106810313,49.2821401598"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -20971,6 +28694,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -20989,20 +28717,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21016,7 +28737,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21028,6 +28772,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21046,20 +28795,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21073,7 +28815,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21085,6 +28850,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21103,20 +28873,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21130,7 +28893,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21142,6 +28928,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21160,20 +28951,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21187,7 +28971,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21199,6 +29006,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21217,20 +29029,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21244,7 +29049,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21256,6 +29084,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21274,20 +29107,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21301,7 +29127,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21313,6 +29162,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21331,20 +29185,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21358,7 +29205,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21370,6 +29240,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21388,20 +29263,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21415,7 +29283,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21427,6 +29318,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21445,20 +29341,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21472,7 +29361,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21484,6 +29396,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21502,20 +29419,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21529,7 +29439,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21541,6 +29474,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21559,20 +29497,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21586,7 +29517,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21598,6 +29552,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21616,20 +29575,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21643,7 +29595,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21655,6 +29630,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21673,20 +29653,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85865011,
@@ -21700,7 +29673,30 @@
             "neighbourhood_id": 85865011,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.270226,
+          "lon": -123.166068
+        },
+        "BoundingBox": "-123.184938398,49.2530896659,-123.143005371,49.292924629"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21712,6 +29708,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21730,20 +29731,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -21757,7 +29751,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21769,6 +29786,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21787,20 +29809,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -21814,7 +29829,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21826,6 +29864,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]
@@ -21844,20 +29887,13 @@
             "country_id": 85633041,
             "region_id": 85682117
           }
-        ]
-      },
-      {
-        "Id": 101741075,
-        "Name": "Vancouver",
-        "Placetype": "locality",
-        "Hierarchy": [
-          {
-            "continent_id": 102191575,
-            "country_id": 85633041,
-            "locality_id": 101741075,
-            "region_id": 85682117
-          }
-        ]
+        ],
+        "Centroid": {
+          "lat": 54.65437,
+          "lon": -124.834255
+        },
+        "BoundingBox": "-139.061110259,48.22455359,-114.05382241,60.0020482135",
+        "Abbrev": "BC"
       },
       {
         "Id": 85866529,
@@ -21871,7 +29907,30 @@
             "neighbourhood_id": 85866529,
             "region_id": 85682117
           }
-        ]
+        ],
+        "Centroid": {
+          "lat": 49.271844,
+          "lon": -123.13909
+        },
+        "BoundingBox": "-123.151245117,49.2642199886,-123.125152588,49.2794006649"
+      },
+      {
+        "Id": 101741075,
+        "Name": "Vancouver",
+        "Placetype": "locality",
+        "Hierarchy": [
+          {
+            "continent_id": 102191575,
+            "country_id": 85633041,
+            "locality_id": 101741075,
+            "region_id": 85682117
+          }
+        ],
+        "Centroid": {
+          "lat": 49.253892,
+          "lon": -123.112782
+        },
+        "BoundingBox": "-123.224789519,49.1984374893,-123.023298006,49.3161729716"
       },
       {
         "Id": 85633041,
@@ -21883,6 +29942,11 @@
             "country_id": 85633041
           }
         ],
+        "Centroid": {
+          "lat": 61.373126,
+          "lon": -98.316063
+        },
+        "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
         "Abbrev": "CAN"
       }
     ]

--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -25,7 +25,6 @@ var defaultLayers = module.exports.defaultLayers = [
   'borough', // 5
   'county', // 18166
   'dependency', // 39
-  'disputed', // 39
   'localadmin', // 106880
   'locality', // 160372
   'macrocounty', // 350

--- a/test/pip/data/expectedLayerLocalizedNamesTestResults.json
+++ b/test/pip/data/expectedLayerLocalizedNamesTestResults.json
@@ -10,7 +10,12 @@
           "country_id": "85632685",
           "region_id": 85688161
         }
-      ]
+      ],
+      "Centroid": {
+        "lat": 55.661893,
+        "lon": 37.645064
+      },
+      "BoundingBox": "35.1436343294,54.2551915472,40.2055817652,56.9616854907"
     },
     {
       "Id": 85632685,
@@ -23,6 +28,11 @@
           "empire_id": "874393555"
         }
       ],
+      "Centroid": {
+        "lat": 61.996728,
+        "lon": 96.665965
+      },
+      "BoundingBox": "-179.999983092,41.185353,179.999983111,81.86164093",
       "Abbrev": "RUS"
     }
   ],
@@ -37,7 +47,12 @@
           "country_id": 85633111,
           "region_id": 85682499
         }
-      ]
+      ],
+      "Centroid": {
+        "lat": 52.501535,
+        "lon": 13.40184
+      },
+      "BoundingBox": "13.088333,52.338242,13.7604695,52.674917"
     },
     {
       "Id": 85633111,
@@ -49,6 +64,11 @@
           "country_id": 85633111
         }
       ],
+      "Centroid": {
+        "lat": 51.112876,
+        "lon": 10.391873
+      },
+      "BoundingBox": "5.866003,47.2703515,15.0414895,55.0573745",
       "Abbrev": "DEU"
     }
   ],
@@ -63,37 +83,29 @@
           "country_id": 85632171,
           "region_id": 85669521
         }
-      ]
+      ],
+      "Centroid": {
+        "lat": 28.058568,
+        "lon": 89.972312
+      },
+      "BoundingBox": "89.4173636779,27.7152853465,90.5976019387,28.3583989315"
     },
     {
-      "Id": 85632719,
-      "Name": "Bhutan claimed by China",
-      "Placetype": "disputed",
-      "Hierarchy": [
-        {
-          "continent_id": 102191569,
-          "country_id": 85632695,
-          "disputed_id": 85632719
-        },
-        {
-          "continent_id": 102191569,
-          "country_id": 85632171,
-          "disputed_id": 85632719
-        }
-      ]
-    },
-    {
-      "Id": 85632695,
-      "Name": "中國",
+      "Id": 85632171,
+      "Name": "འབྲུག་ཡུལ་",
       "Placetype": "country",
       "Hierarchy": [
         {
           "continent_id": 102191569,
-          "country_id": 85632695,
-          "empire_id": 136253041
+          "country_id": 85632171
         }
       ],
-      "Abbrev": "CHN"
+      "Centroid": {
+        "lat": 27.395689,
+        "lon": 90.432033
+      },
+      "BoundingBox": "88.746474,26.702016,92.1251268,28.246987",
+      "Abbrev": "BTN"
     }
   ],
   [
@@ -107,39 +119,12 @@
           "country_id": 85633041
         }
       ],
+      "Centroid": {
+        "lat": 61.373126,
+        "lon": -98.316063
+      },
+      "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
       "Abbrev": "CAN"
-    }
-  ],
-  [
-    {
-      "Id": 85632719,
-      "Name": "Bhutan claimed by China",
-      "Placetype": "disputed",
-      "Hierarchy": [
-        {
-          "continent_id": 102191569,
-          "country_id": 85632695,
-          "disputed_id": 85632719
-        },
-        {
-          "continent_id": 102191569,
-          "country_id": 85632171,
-          "disputed_id": 85632719
-        }
-      ]
-    },
-    {
-      "Id": 85632695,
-      "Name": "中國",
-      "Placetype": "country",
-      "Hierarchy": [
-        {
-          "continent_id": 102191569,
-          "country_id": 85632695,
-          "empire_id": 136253041
-        }
-      ],
-      "Abbrev": "CHN"
     }
   ]
 ]

--- a/test/pip/data/expectedLayerTestResults.json
+++ b/test/pip/data/expectedLayerTestResults.json
@@ -10,7 +10,12 @@
           "country_id": "85632685",
           "region_id": 85688161
         }
-      ]
+      ],
+      "Centroid": {
+        "lat": 55.661893,
+        "lon": 37.645064
+      },
+      "BoundingBox": "35.1436343294,54.2551915472,40.2055817652,56.9616854907"
     },
     {
       "Id": 85632685,
@@ -23,6 +28,11 @@
           "empire_id": "874393555"
         }
       ],
+      "Centroid": {
+        "lat": 61.996728,
+        "lon": 96.665965
+      },
+      "BoundingBox": "-179.999983092,41.185353,179.999983111,81.86164093",
       "Abbrev": "RUS"
     }
   ],
@@ -37,7 +47,12 @@
           "country_id": 85633111,
           "region_id": 85682499
         }
-      ]
+      ],
+      "Centroid": {
+        "lat": 52.501535,
+        "lon": 13.40184
+      },
+      "BoundingBox": "13.088333,52.338242,13.7604695,52.674917"
     },
     {
       "Id": 85633111,
@@ -49,6 +64,11 @@
           "country_id": 85633111
         }
       ],
+      "Centroid": {
+        "lat": 51.112876,
+        "lon": 10.391873
+      },
+      "BoundingBox": "5.866003,47.2703515,15.0414895,55.0573745",
       "Abbrev": "DEU"
     }
   ],
@@ -63,37 +83,29 @@
           "country_id": 85632171,
           "region_id": 85669521
         }
-      ]
+      ],
+      "Centroid": {
+        "lat": 28.058568,
+        "lon": 89.972312
+      },
+      "BoundingBox": "89.4173636779,27.7152853465,90.5976019387,28.3583989315"
     },
     {
-      "Id": 85632719,
-      "Name": "Bhutan claimed by China",
-      "Placetype": "disputed",
-      "Hierarchy": [
-        {
-          "continent_id": 102191569,
-          "country_id": 85632695,
-          "disputed_id": 85632719
-        },
-        {
-          "continent_id": 102191569,
-          "country_id": 85632171,
-          "disputed_id": 85632719
-        }
-      ]
-    },
-    {
-      "Id": 85632695,
-      "Name": "China",
+      "Id": 85632171,
+      "Name": "Bhutan",
       "Placetype": "country",
       "Hierarchy": [
         {
           "continent_id": 102191569,
-          "country_id": 85632695,
-          "empire_id": 136253041
+          "country_id": 85632171
         }
       ],
-      "Abbrev": "CHN"
+      "Centroid": {
+        "lat": 27.395689,
+        "lon": 90.432033
+      },
+      "BoundingBox": "88.746474,26.702016,92.1251268,28.246987",
+      "Abbrev": "BTN"
     }
   ],
   [
@@ -107,39 +119,12 @@
           "country_id": 85633041
         }
       ],
+      "Centroid": {
+        "lat": 61.373126,
+        "lon": -98.316063
+      },
+      "BoundingBox": "-141.005549,41.669086,-52.615931,83.116116",
       "Abbrev": "CAN"
-    }
-  ],
-  [
-    {
-      "Id": 85632719,
-      "Name": "Bhutan claimed by China",
-      "Placetype": "disputed",
-      "Hierarchy": [
-        {
-          "continent_id": 102191569,
-          "country_id": 85632695,
-          "disputed_id": 85632719
-        },
-        {
-          "continent_id": 102191569,
-          "country_id": 85632171,
-          "disputed_id": 85632719
-        }
-      ]
-    },
-    {
-      "Id": 85632695,
-      "Name": "China",
-      "Placetype": "country",
-      "Hierarchy": [
-        {
-          "continent_id": 102191569,
-          "country_id": 85632695,
-          "empire_id": 136253041
-        }
-      ],
-      "Abbrev": "CHN"
     }
   ]
 ]

--- a/test/pip/data/layerTestData.json
+++ b/test/pip/data/layerTestData.json
@@ -1,7 +1,6 @@
 [
   { "longitude": -123.12019, "latitude": 49.274507, "layers": [ "country" ] },
   { "longitude": 90.051874, "latitude": 28.2479, "notes": "Canada" },
-  { "longitude": 90.051874, "latitude": 28.2479, "layers": [ "disputed" ] },
   { "longitude": 37.076846, "latitude": 56.063863, "notes": "Moscow, Russia"},
   { "longitude": 13.407003, "latitude": 52.524961, "notes": "Berlin, Germany" }
 ]

--- a/test/pip/testDependencyMode.js
+++ b/test/pip/testDependencyMode.js
@@ -14,7 +14,6 @@ const layers = [
   'country', // 216
   'county', // 18166
   'dependency', // 39
-  'disputed', // 39
   'localadmin', // 106880
   'locality', // 160372
   'macrocounty', // 350

--- a/test/pip/testLayerLookup.js
+++ b/test/pip/testLayerLookup.js
@@ -18,7 +18,6 @@ const layers = [
   'country', // 216
   //'county', // 18166
   'dependency', // 39
-  'disputed', // 39
   //'localadmin', // 106880
   //'locality', // 160372
   'macrocounty', // 350

--- a/test/pip/testLayerLookupLocalizedNames.js
+++ b/test/pip/testLayerLookupLocalizedNames.js
@@ -18,7 +18,6 @@ const layers = [
   'country', // 216
   //'county', // 18166
   'dependency', // 39
-  'disputed', // 39
   //'localadmin', // 106880
   //'locality', // 160372
   'macrocounty', // 350


### PR DESCRIPTION
This is the only place we have support for the `disputed` place type.  It's not supported in the model and ends up wasting execution time in admin lookup.  