### PR TITLE
fix test by not passing doc along in case of error

### DIFF
--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -31,11 +31,18 @@ function createPipResolverStream(pipResolver) {
     }
 
     pipResolver.lookup(doc.getCentroid(), getAdminLayers(doc.getLayer()), (err, result) => {
-
-      // assume errors at this point are fatal, so pass them upstream to kill stream
       if (err) {
-        logger.error(err);
-        return callback(new Error('PIP server failed: ' + (err.message || JSON.stringify(err))));
+        // if there's an error, just log it and move on
+        const parts = [
+          `id:${doc.getGid()}`,
+          `lat:${doc.getCentroid().lat}`,
+          `lon:${doc.getCentroid().lon}`,
+          `PIP server failed: ${(err.message || JSON.stringify(err))}`
+        ];
+
+        logger.error(parts.join('|'));
+        // don't pass the unmodified doc along
+        return callback();
       }
 
       // log results w/o country OR any multiples

--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -33,14 +33,11 @@ function createPipResolverStream(pipResolver) {
     pipResolver.lookup(doc.getCentroid(), getAdminLayers(doc.getLayer()), (err, result) => {
       if (err) {
         // if there's an error, just log it and move on
-        const parts = [
-          `id:${doc.getGid()}`,
-          `lat:${doc.getCentroid().lat}`,
-          `lon:${doc.getCentroid().lon}`,
-          `PIP server failed: ${(err.message || JSON.stringify(err))}`
-        ];
-
-        logger.error(parts.join('|'));
+        logger.error(`PIP server failed: ${(err.message || JSON.stringify(err))}`, {
+          id: doc.getGid(),
+          lat: doc.getCentroid().lat,
+          lon: doc.getCentroid().lon
+        });
         // don't pass the unmodified doc along
         return callback();
       }

--- a/test/lookupStreamTest.js
+++ b/test/lookupStreamTest.js
@@ -2,6 +2,7 @@ const tape = require('tape');
 const event_stream = require('event-stream');
 const Document = require('pelias-model').Document;
 const _ = require('lodash');
+const proxyquire = require('proxyquire').noCallThru();
 
 const stream = require('../src/lookupStream');
 
@@ -157,33 +158,63 @@ tape('tests', (test) => {
   test.test('resolver throwing error should push doc onto stream unmodified', (t) => {
     const input = [
       new Document( 'whosonfirst', 'placetype', '1')
-        .setCentroid({ lat: 12.121212, lon: 21.212121 })
+        .setCentroid({ lat: 12.121212, lon: 21.212121 }),
+      new Document( 'whosonfirst', 'placetype', '2')
+        .setCentroid({ lat: 13.131313, lon: 31.313131 }),
+      new Document( 'whosonfirst', 'placetype', '3')
+        .setCentroid({ lat: 14.141414, lon: 41.414141 })
     ];
 
     const expected = [
       new Document( 'whosonfirst', 'placetype', '1')
-        .setCentroid({ lat: 12.121212, lon: 21.212121 })
+        .setCentroid({ lat: 12.121212, lon: 21.212121 }),
+      new Document( 'whosonfirst', 'placetype', '3')
+        .setCentroid({ lat: 14.141414, lon: 41.414141 })
     ];
 
     const resolver = {
       lookup: (centroid, search_layers, callback) => {
-        setTimeout(callback, 0, 'this is an error', {region: 'Region'});
+        // return an error only for the second doc
+        if (centroid.lat === 13.131313) {
+          setTimeout(callback, 0, 'this is a resolver error');
+        } else {
+          setTimeout(callback, 0, null, {});
+        }
       }
     };
 
-    const lookupStream = stream(resolver);
+    const errorMessages = [];
 
-    const input_stream = event_stream.readArray(input);
-    const destination_stream = event_stream.writeArray(() => {
-      t.fail('this stream should not have been called');
+    const lookupStream = proxyquire('../src/lookupStream', {
+      'pelias-logger': {
+        winston: {
+          transports: {
+            File: function() {
+
+            }
+          }
+        },
+        get: (layer, opts) => {
+          return {
+            error: (message) => {
+              errorMessages.push(message);
+            },
+            info: (message) => {}
+          };
+        }
+      }
+
+    })(resolver);
+
+    test_stream(input, lookupStream, (err, actual) => {
+      t.deepEquals(actual, expected, 'only error-free records should pass through');
+      t.deepEquals(errorMessages, [
+        'id:whosonfirst:placetype:2|' +
+        'lat:13.131313|' +
+        'lon:31.313131|' +
+        'PIP server failed: "this is a resolver error"']);
       t.end();
     });
-
-    input_stream.pipe(lookupStream).on('error', (e) => {
-      t.equal(e.message, 'PIP server failed: "this is an error"');
-      t.deepEqual(input, expected, 'the document should not have been modified');
-      t.end();
-    }).pipe(destination_stream);
 
   });
 

--- a/test/lookupStreamTest.js
+++ b/test/lookupStreamTest.js
@@ -156,6 +156,8 @@ tape('tests', (test) => {
   });
 
   test.test('resolver throwing error should push doc onto stream unmodified', (t) => {
+    t.plan(3);
+
     const input = [
       new Document( 'whosonfirst', 'placetype', '1')
         .setCentroid({ lat: 12.121212, lon: 21.212121 }),
@@ -196,8 +198,13 @@ tape('tests', (test) => {
         },
         get: (layer, opts) => {
           return {
-            error: (message) => {
-              errorMessages.push(message);
+            error: (message, additional) => {
+              t.equals(message, 'PIP server failed: "this is a resolver error"');
+              t.deepEquals(additional, {
+                id: 'whosonfirst:placetype:2',
+                lat: 13.131313,
+                lon: 31.313131
+              });
             },
             info: (message) => {}
           };
@@ -208,11 +215,6 @@ tape('tests', (test) => {
 
     test_stream(input, lookupStream, (err, actual) => {
       t.deepEquals(actual, expected, 'only error-free records should pass through');
-      t.deepEquals(errorMessages, [
-        'id:whosonfirst:placetype:2|' +
-        'lat:13.131313|' +
-        'lon:31.313131|' +
-        'PIP server failed: "this is a resolver error"']);
       t.end();
     });
 


### PR DESCRIPTION
This fixes the test that's failing for @tigerlily-he 

In the event of a pipResolver error, the message (along with gid, lat, and lon) are logged and the document is not forwarded downstream.  