### PR TITLE
Remove records with geometry.type = point

### DIFF
--- a/src/pip/components/filterOutPointRecords.js
+++ b/src/pip/components/filterOutPointRecords.js
@@ -1,0 +1,9 @@
+var filter = require('through2-filter');
+// this returns a filter stream that returns true if a WOF record has a field
+// "geometry" with "type" NOT equalled to "Point"
+module.exports.create = function create() {
+  return filter.obj(function(wofData) {
+    return wofData.geometry.hasOwnProperty('type') &&
+           wofData.geometry.type !== 'Point';
+  });
+};

--- a/src/pip/readStream.js
+++ b/src/pip/readStream.js
@@ -3,6 +3,7 @@ const whosonfirst = require('pelias-whosonfirst');
 const extractFields = require('./components/extractFields');
 const simplifyGeometry = require('./components/simplifyGeometry');
 const filterOutUnimportantRecords = require('./components/filterOutUnimportantRecords');
+const filterOutPointRecords = require('./components/filterOutPointRecords');
 
 /**
  * This function loads a WOF metadata file, CSV parses it, extracts fields,
@@ -23,6 +24,7 @@ function readData(datapath, layer, localizedAdminNames, callback) {
     .pipe(whosonfirst.loadJSON(datapath, false))
     .pipe(whosonfirst.recordHasIdAndProperties())
     .pipe(whosonfirst.isActiveRecord())
+    .pipe(filterOutPointRecords.create())
     .pipe(filterOutUnimportantRecords.create())
     .pipe(extractFields.create(localizedAdminNames))
     .pipe(simplifyGeometry.create())

--- a/test/pip/components/filterOutPointRecordsTest.js
+++ b/test/pip/components/filterOutPointRecordsTest.js
@@ -1,0 +1,71 @@
+var tape = require('tape');
+var event_stream = require('event-stream');
+
+var filterOutPointRecords = require('../../../src/pip/components/filterOutPointRecords');
+
+function test_stream(input, testedStream, callback) {
+    var input_stream = event_stream.readArray(input);
+    var destination_stream = event_stream.writeArray(callback);
+
+    input_stream.pipe(testedStream).pipe(destination_stream);
+}
+
+tape('filterOutPointNotPolygon', function (test){
+	test.test('record without geometry.type should return false', function(t) {
+		var input = [
+      { geometry: { } },
+      { geometry: {'coordinates':[[[-180.0,-90.0],[-180.0,90.0]]]} }
+		];
+
+		var expected = [];
+		var filter = filterOutPointRecords.create();
+
+		test_stream(input, filter, function(err, actual) {
+     			 t.deepEqual(actual, expected, 'should have returned true');
+     			 t.end();
+   		 });
+	});
+
+  test.test('point record should return false', function(t) {
+		var input = {
+			geometry: {'type':'Point'}
+		};
+
+		var expected = [];
+		var filter = filterOutPointRecords.create();
+
+		test_stream([input], filter, function(err, actual) {
+     			 t.deepEqual(actual, expected, 'should have returned true');
+     			 t.end();
+   		 });
+	});
+
+  test.test('polygon record should return true', function(t) {
+		var input = {
+			geometry: {'type':'Polygon'}
+		};
+
+		var expected = [input];
+		var filter = filterOutPointRecords.create();
+
+		test_stream([input], filter, function(err, actual) {
+     			 t.deepEqual(actual, expected, 'should have returned true');
+     			 t.end();
+   		 });
+	});
+
+  test.test('MultiPolygon record should return true', function(t) {
+		var input = {
+			geometry: {'type':'MultiPolygon'}
+		};
+
+		var expected = [input];
+		var filter = filterOutPointRecords.create();
+
+		test_stream([input], filter, function(err, actual) {
+     			 t.deepEqual(actual, expected, 'should have returned true');
+     			 t.end();
+   		 });
+	});
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -6,3 +6,4 @@ require ('./pip/components/extractFieldsTest.js');
 require ('./pip/components/extractFieldsLocalizedNameTest.js');
 require ('./pip/components/simplifyGeometryTest.js');
 require ('./pip/components/filterOutUnimportantRecordsTest.js');
+require ('./pip/components/filterOutPointRecordsTest.js');


### PR DESCRIPTION
For admin lookup, point records will not contain other points or polygons, so they are unnecessary. Removing them will also speed up the load.

Fixes #118 