### PR TITLE
warn and skip layers with missing WOF metafiles

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -6,7 +6,8 @@ module.exports = Joi.object().keys({
     adminLookup: Joi.object().keys({
       // default maxConcurrentReqs to # of cpus/cores * 10
       maxConcurrentReqs: Joi.number().integer().default(cpus().length*10),
-      enabled: Joi.boolean().default(true)
+      enabled: Joi.boolean().default(true),
+      missingMetafilesAreFatal: Joi.boolean().default(false)
     }).unknown(true),
     whosonfirst: Joi.object().keys({
       datapath: Joi.string()

--- a/src/localPipResolver.js
+++ b/src/localPipResolver.js
@@ -14,7 +14,10 @@ function LocalPipService(datapath, layers) {
   const self = this;
 
   createPipService(datapath, _.defaultTo(layers, []), false, (err, service) => {
-     self.pipService = service;
+    if (err) {
+      throw err;
+    }
+    self.pipService = service;
   });
 
 }

--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -13,6 +13,7 @@ const logger = require( 'pelias-logger' ).get( 'wof-pip-service:master' );
 const async = require('async');
 const _ = require('lodash');
 const fs = require('fs');
+const missingMetafilesAreFatal = require('pelias-config').generate(require('../../schema')).imports.adminLookup.missingMetafilesAreFatal;
 
 let requestCount = 0;
 // worker processes keyed on layer
@@ -43,16 +44,25 @@ module.exports.create = function createPIPService(datapath, layers, localizedAdm
   // ie - _.intersection([1, 2, 3], [3, 1]) === [1, 3]
   layers = _.intersection(defaultLayers, _.isEmpty(layers) ? defaultLayers : layers);
 
-  // further refine the layers by filtering out layers for which there is not metafile
+  // keep track of any missing metafiles for later reporting and error conditions
+  const missingMetafiles = [];
+
+  // further refine the layers by filtering out layers for which there is no metafile
   layers = layers.filter(layer => {
     const filename = path.join(datapath, 'meta', `wof-${layer}-latest.csv`);
 
     if (!fs.existsSync(filename)) {
       logger.error(`unable to locate ${filename}`);
+      missingMetafiles.push(`wof-${layer}-latest.csv`);
       return false;
     }
     return true;
   });
+
+  // if there are missing metafiles and this is fatal, then return an error
+  if (!_.isEmpty(missingMetafiles) && missingMetafilesAreFatal) {
+    return callback(`unable to locate meta files in ${path.join(datapath, 'meta')}: ${missingMetafiles.join(', ')}`);
+  }
 
   logger.info(`starting with layers ${layers}`);
 

--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -43,6 +43,17 @@ module.exports.create = function createPIPService(datapath, layers, localizedAdm
   // ie - _.intersection([1, 2, 3], [3, 1]) === [1, 3]
   layers = _.intersection(defaultLayers, _.isEmpty(layers) ? defaultLayers : layers);
 
+  // further refine the layers by filtering out layers for which there is not metafile
+  layers = layers.filter(layer => {
+    const filename = path.join(datapath, 'meta', `wof-${layer}-latest.csv`);
+
+    if (!fs.existsSync(filename)) {
+      logger.warn(`unable to locate ${filename}`);
+      return false;
+    }
+    return true;
+  });
+
   logger.info(`starting with layers ${layers}`);
 
   // load all workers

--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -48,7 +48,7 @@ module.exports.create = function createPIPService(datapath, layers, localizedAdm
     const filename = path.join(datapath, 'meta', `wof-${layer}-latest.csv`);
 
     if (!fs.existsSync(filename)) {
-      logger.warn(`unable to locate ${filename}`);
+      logger.error(`unable to locate ${filename}`);
       return false;
     }
     return true;

--- a/test/localPipResolverTest.js
+++ b/test/localPipResolverTest.js
@@ -131,4 +131,18 @@ tape('tests', (test) => {
 
   });
 
+  test.test('createPipService returning error should throw exception', t => {
+    const resolver = proxyquire('../src/localPipResolver', {
+      './pip/index': {
+        create: (datapath, layers, localizedAdminNames, callback) => {
+          callback('this is a localPipResolver error');
+        }
+      }
+    });
+
+    t.throws(resolver.bind('this is the datapath', ['layer 1', 'layer 2']), /this is a localPipResolver error/);
+    t.end();
+
+  });
+
 });

--- a/test/pip/index.js
+++ b/test/pip/index.js
@@ -586,7 +586,7 @@ tape('PiP tests', test => {
     });
 
   });
-  
+
   test.test('layers missing metafiles should not load and skip lookup at those layers', t => {
     const logger = require('pelias-mock-logger')();
 
@@ -636,7 +636,7 @@ tape('PiP tests', test => {
 
       // initialize PiP with neighbourhood/locality (that don't exist) and borough (which does exist)
       pip.create(temp_dir, ['neighbourhood', 'borough'], false, (err, service) => {
-        t.deepEquals(logger.getWarnMessages(), [
+        t.deepEquals(logger.getErrorMessages(), [
           'unable to locate ' + path.join(temp_dir, 'meta', `wof-neighbourhood-latest.csv`)
         ]);
 

--- a/test/pip/index.js
+++ b/test/pip/index.js
@@ -587,7 +587,7 @@ tape('PiP tests', test => {
 
   });
 
-  test.test('layers missing metafiles should not load and skip lookup at those layers', t => {
+  test.test('layers missing metafiles when not fatal should report error and skip lookup at those layers', t => {
     const logger = require('pelias-mock-logger')();
 
     temp.mkdir('tmp_wof_data', (err, temp_dir) => {
@@ -658,6 +658,82 @@ tape('PiP tests', test => {
           service.end();
           t.end();
         });
+
+      });
+
+    });
+
+  });
+
+  test.test('layers missing metafiles when fatal should return error on callback', t => {
+    const logger = require('pelias-mock-logger')();
+
+    temp.mkdir('tmp_wof_data', (err, temp_dir) => {
+      fs.mkdirSync(path.join(temp_dir, 'data'));
+      fs.mkdirSync(path.join(temp_dir, 'meta'));
+
+      // write out the WOF meta file with the minimum required fields
+      fs.writeFileSync(
+        path.join(temp_dir, 'meta', 'wof-borough-latest.csv'),
+        `id,name,path${EOL}456,borough name,borough_record.geojson${EOL}`);
+
+      // setup a borough WOF record that's the exact same geometry as neighbourhood
+      const borough_record = {
+        id: 456,
+        type: 'Feature',
+        properties: {
+          'geom:bbox': '1,1,2,2',
+          'geom:latitude': 1.5,
+          'geom:longitude': 1.5,
+          'mz:hierarchy_label': 1,
+          'wof:hierarchy': [
+            {
+              borough_id: 456
+            }
+          ],
+          'wof:id': 456,
+          'wof:name': 'borough name',
+          'wof:placetype': 'borough'
+        },
+        geometry: {
+          coordinates: [
+            [
+              [1,1],[2,1],[2,2],[1,2],[1,1]
+            ]
+          ],
+          type: 'Polygon'
+        }
+      };
+
+      // and write the records to file
+      fs.writeFileSync(path.join(temp_dir, 'data', 'borough_record.geojson'), JSON.stringify(borough_record));
+
+      const pip = proxyquire('../../src/pip/index', {
+        'pelias-logger': logger,
+        'pelias-config': {
+          generate: () => {
+            return {
+              imports: {
+                adminLookup: {
+                  missingMetafilesAreFatal: true
+                }
+              }
+            };
+          }
+        }
+      });
+
+      // initialize PiP with neighbourhood (that doesn't exist) and borough (which does exist)
+      pip.create(temp_dir, ['neighbourhood', 'borough', 'locality'], false, (err, service) => {
+        t.deepEquals(logger.getErrorMessages(), [
+          'unable to locate ' + path.join(temp_dir, 'meta', `wof-neighbourhood-latest.csv`),
+          'unable to locate ' + path.join(temp_dir, 'meta', `wof-locality-latest.csv`)
+        ], 'should have an error message');
+
+        t.deepEquals(err, `unable to locate meta files in ${path.join(temp_dir, 'meta')}` +
+          ': wof-neighbourhood-latest.csv, wof-locality-latest.csv');
+        t.notOk(service);
+        t.end();
 
       });
 

--- a/test/schema.js
+++ b/test/schema.js
@@ -226,6 +226,75 @@ tape('test configuration scenarios', (test) =>  {
 
   });
 
+  test.test('non-boolean imports.adminLookup.missingMetafilesAreFatal should throw error', (t) =>  {
+    [null, 'string', {}, [], 17].forEach((value) => {
+      const config = {
+        imports: {
+          adminLookup: {
+            maxConcurrentReqs: 17,
+            missingMetafilesAreFatal: value
+          },
+          whosonfirst: {
+            datapath: 'datapath value'
+          }
+        }
+      };
+
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"missingMetafilesAreFatal" must be a boolean');
+
+    });
+
+    t.end();
+
+  });
+
+  test.test('boolean imports.adminLookup.missingMetafilesAreFatal should not throw error', (t) =>  {
+    [true, false].forEach((value) => {
+      const config = {
+        imports: {
+          adminLookup: {
+            maxConcurrentReqs: 17,
+            missingMetafilesAreFatal: value
+          },
+          whosonfirst: {
+            datapath: 'datapath value'
+          }
+        }
+      };
+
+      const result = Joi.validate(config, schema);
+
+      t.notOk(result.error);
+
+    });
+
+    t.end();
+
+  });
+
+  test.test('missing imports.adminLookup.missingMetafilesAreFatal should default to false', (t) =>  {
+    const config = {
+      imports: {
+        adminLookup: {
+          maxConcurrentReqs: 17
+        },
+        whosonfirst: {
+          datapath: 'datapath value'
+        }
+      }
+    };
+
+    const result = Joi.validate(config, schema);
+
+    t.notOk(result.error);
+    t.equals(result.value.imports.adminLookup.missingMetafilesAreFatal, false);
+    t.end();
+
+  });
+
   test.test('integer imports.adminLookup.maxConcurrentReqs should not throw error', (t) =>  {
     const config = {
       imports: {


### PR DESCRIPTION
Fixes #157 

Introduces boolean `imports.admin.missingMetafilesAreFatal` for what to do when WOF metafiles are missing while starting.  Defaults to *false* so we'll have to enable in our configs.  /src/pip/index.js returns an error in the callback while src/localPipResolver.js throws an error which will shutdown importers.  