### PR TITLE
Enable HTTP Keep-Alive for remote PIP service

### DIFF
--- a/src/remotePipResolver.js
+++ b/src/remotePipResolver.js
@@ -3,6 +3,10 @@
 const logger = require('pelias-logger').get('wof-admin-lookup');
 const _ = require('lodash');
 const request = require('request');
+const http = require('http');
+
+// Use one HTTP agent with HTTP keep alive enabled across all requests
+const keepAliveAgent = new http.Agent({ keepAlive: true });
 
 /**
  * RemotePIPService class
@@ -24,6 +28,7 @@ RemotePIPService.prototype.lookup = function lookup(centroid, _, callback) {
   const options = {
     uri: `${this.pipServiceURL}/${centroid.lon}/${centroid.lat}`,
     method: 'GET',
+    agent: keepAliveAgent,
     json: true
   };
 


### PR DESCRIPTION
Use an HTTP agent with keep-alive enabled. This has a significant impact on performance, even in low latency situations. On the Mapzen Search dev environment running in AWS, it increases performance from from about 150 imports/sec to around 1000!

This is a follow up PR to @tadjik1's helpful PR: https://github.com/pelias/wof-admin-lookup/pull/162