### PR TITLE
Use Keep-Alive HTTP connection

### DIFF
--- a/src/remotePipResolver.js
+++ b/src/remotePipResolver.js
@@ -24,6 +24,7 @@ RemotePIPService.prototype.lookup = function lookup(centroid, _, callback) {
   const options = {
     uri: `${this.pipServiceURL}/${centroid.lon}/${centroid.lat}`,
     method: 'GET',
+    forever: true, // use keepalive
     json: true
   };
 


### PR DESCRIPTION
Request module supports keep-alive connections, we can pass option `forever` to enable it.
Link to documentation: https://github.com/request/request#requestoptions-callback

Could be used instead of #169. Both are working fine, so it's more about convention.