### PR TITLE
Handle PIP child_process `error` and `close` events

### DIFF
--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -69,7 +69,6 @@ module.exports.create = function createPIPService(datapath, layers, localizedAdm
   // load all workers
   async.forEach(layers, (layer, done) => {
       startWorker(datapath, layer, localizedAdminNames, function (err, worker) {
-        workers[layer] = worker;
         done();
       });
     },
@@ -124,6 +123,7 @@ function killAllWorkers() {
 
 function startWorker(datapath, layer, localizedAdminNames, callback) {
   const worker = childProcess.fork(path.join(__dirname, 'worker'), [layer, datapath, localizedAdminNames]);
+  workers[layer] = worker;
 
   worker.on('message', msg => {
     if (msg.type === 'loaded') {

--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -146,7 +146,7 @@ function startWorker(datapath, layer, localizedAdminNames, callback) {
 
   });
 
-  worker.on('close', (code, signal)  => {
+  worker.on('exit', (code, signal)  => {
     // the `.killed` property will be true if a kill signal was previously sent to this worker
     // in that case, the worker shutting down is not an error
     // if the worker _was not_ told to shut down, it's a big problem


### PR DESCRIPTION
## Background

The multi-process model our admin lookup code uses has been susceptible to issues with the child processes shutting down unexpectedly for a long time.

This can happen for many reasons, some of which are:
* the child process ran out of memory, for example in #117
* the Who's on First data is missing or incomplete. This has probably caused many, many confusing cases for our users

In my testing today, the PIP service will shut down after a worker has died, but only after a request has come in that actually ends up hitting that layer. For higher, less common layers like `ocean`, this may not happen for a long time.

The importers, when using `wof-admin-lookup` locally, are in even worse shape, and will often hang indefinitely.

In either case, a worker shutting down before all other workers have loaded will cause an infinite hang.

## Changes

This PR adds handlers for both the `close` and `error` events emitted by child processes. It determines if the event was emitted intentionally or not, for example because the importer or PIP service is shutting down and has told the workers to shut down, or unintentionally, in which case it's an error.

In the error case, the behavior is now to send the `SIGTERM` signal to all other workers and throw an exception so that the entire importer or PIP service **quits immediately**. It writes a clear error to stderr
showing which worker shut down, which should help diagnose any issues.

By shutting down immediately, time spent in an invalid state is minimized.

For Mapzen Search production, as soon as the PIP service has fully shut down the instance will be taken out of the load balancer until the service has restarted, so again it's advantageous to shut down as quickly as possible.

## Testing

I've tested this locally with both importers and the PIP service by manually sending `SIGTERM` to a worker. Worker shutdown both during loading and after they have all loaded is now handled well. Of course more testing would be appreciated.

Fixes #138