### PR TITLE
feat: Expose localPipResolver function

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,12 +19,17 @@ function resolver(layers) {
   if (_.has(peliasConfig, 'imports.services.pip')) {
     return require('./src/remotePipResolver')(peliasConfig.imports.services.pip, layers);
   } else {
-    const datapath = peliasConfig.imports.whosonfirst.datapath;
-    return require('./src/localPipResolver')(datapath, layers);
+    return localResolver(layers);
   }
+}
+
+function localResolver(layers) {
+  const datapath = peliasConfig.imports.whosonfirst.datapath;
+  return require('./src/localPipResolver')(datapath, layers);
 }
 
 module.exports = {
   create: create,
-  resolver: resolver
+  resolver: resolver,
+  localResolver: localResolver
 };

--- a/test/index.js
+++ b/test/index.js
@@ -199,4 +199,40 @@ tape('tests for main entry point', (test) => {
 
   });
 
+  test.test('localResolver function should return local resolver even if resolver would return a remote resolver', (t) => {
+    const resolver = proxyquire('../index', {
+      // verify the schema
+      './schema': 'this is the schema',
+      'pelias-config': {
+        generate: (schema) => {
+          t.equals(schema, 'this is the schema');
+
+          return {
+            imports: {
+              adminLookup: {
+                enabled: true,
+                maxConcurrentReqs: 21
+              },
+              whosonfirst: {
+                datapath: 'this is the wof datapath'
+              },
+              services: {
+                pip: {
+                  url: 'this is the url'
+                }
+              }
+            }
+          };
+
+        }
+      },
+      './src/localPipResolver': (datapath, layers) => {
+        t.equals(datapath, 'this is the wof datapath');
+        t.deepEquals(layers, ['layer 1', 'layer 2']);
+        return 'this is the resolver';
+      }
+    }).localResolver(['layer 1', 'layer 2']);
+    t.equal(resolver, 'this is the resolver');
+    t.end();
+  });
 });


### PR DESCRIPTION
In some cases, such as running the PIP service itself, we don't want
wof-admin-lookup to autodetect whether to to use a remote or local PIP
service.

This allows us to keep a single `pelias.json` for an entire Pelias
deployment, with remote PIP turned on, without the PIP service
attempting to recursively connect to itself and break.