### PR TITLE
feat: Use warning log level for non-fatal error

### DIFF
--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -52,7 +52,12 @@ module.exports.create = function createPIPService(datapath, layers, localizedAdm
     const filename = path.join(datapath, 'meta', `wof-${layer}-latest.csv`);
 
     if (!fs.existsSync(filename)) {
-      logger.error(`unable to locate ${filename}`);
+      const message = `unable to locate ${filename}`;
+      if (missingMetafilesAreFatal) {
+        logger.error(message);
+      } else {
+        logger.warn(message);
+      }
       missingMetafiles.push(`wof-${layer}-latest.csv`);
       return false;
     }

--- a/test/pip/index.js
+++ b/test/pip/index.js
@@ -636,7 +636,7 @@ tape('PiP tests', test => {
 
       // initialize PiP with neighbourhood/locality (that don't exist) and borough (which does exist)
       pip.create(temp_dir, ['neighbourhood', 'borough'], false, (err, service) => {
-        t.deepEquals(logger.getErrorMessages(), [
+        t.deepEquals(logger.getWarnMessages(), [
           'unable to locate ' + path.join(temp_dir, 'meta', `wof-neighbourhood-latest.csv`)
         ]);
 


### PR DESCRIPTION
By default, missing meta-files is a non-fatal error condition. However, the log output was always made at the `error` level.

This change keeps the existing behavior when missing metafiles ARE fatal, and logs a message as a warning when not.