### PR TITLE
index a version of postalcodes which doesnt include whitespace

### DIFF
--- a/src/pip/components/extractFields.js
+++ b/src/pip/components/extractFields.js
@@ -44,7 +44,21 @@ module.exports.create = function(enableLocalizedNames) {
     // use different abbreviation field for country
     if (res.properties.Placetype === 'country') {
       res.properties.Abbrev = wofData.properties['wof:country_alpha3'];
-    } else {
+
+    // use different abbreviation field for postalcode
+    } else if (res.properties.Placetype === 'postalcode') {
+
+      // index a version of postcode which doesn't contain whitespace
+      if (typeof res.properties.Name === 'string') {
+        var sans_whitespace = res.properties.Name.replace(/\s/g, '');
+        if (sans_whitespace !== res.properties.Name) {
+          res.properties.Abbrev = sans_whitespace;
+        }
+      }
+    }
+
+    // abbreviations for all other placetypes
+    if (!res.properties.Abbrev) {
       res.properties.Abbrev = wofData.properties['wof:abbreviation'];
     }
 

--- a/test/pip/components/extractFieldsTest.js
+++ b/test/pip/components/extractFieldsTest.js
@@ -360,4 +360,131 @@ tape('extractFields tests', function(test) {
 
   });
 
+  test.test('abbreviations: country records should prefer wof:country_alpha3', t => {
+    const input = {
+      properties: {
+        'wof:id': 17,
+        'wof:name': 'Feature name',
+        'wof:abbreviation': 'Feature abbreviation',
+        'wof:placetype': 'country',
+        'wof:country_alpha3': 'ABC',
+        'wof:hierarchy': [],
+        'geom:latitude': 12.121212,
+        'geom:longitude': 21.212121,
+        'geom:bbox': 'Feature boundingbox'
+      },
+      geometry: 'Geometry'
+    };
+
+    const expected = {
+      properties: {
+        Id: 17,
+        Name: 'Feature name',
+        Abbrev: 'ABC',
+        Placetype: 'country',
+        Hierarchy: [
+          [ 17 ]
+        ],
+        Centroid: {
+          lat: 12.121212,
+          lon: 21.212121
+        },
+        BoundingBox: 'Feature boundingbox'
+      },
+      geometry: 'Geometry'
+    };
+
+    const extractFields = require('../../../src/pip/components/extractFields').create();
+
+    test_stream([input], extractFields, (err, actual) => {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
+  test.test('abbreviations: postalcode records should prefer sans-whitespace name when name contains whitespace', t => {
+    const input = {
+      properties: {
+        'wof:id': 17,
+        'wof:name': 'E8 1DN',
+        'wof:abbreviation': 'Feature abbreviation',
+        'wof:placetype': 'postalcode',
+        'wof:hierarchy': [],
+        'geom:latitude': 12.121212,
+        'geom:longitude': 21.212121,
+        'geom:bbox': 'Feature boundingbox'
+      },
+      geometry: 'Geometry'
+    };
+
+    const expected = {
+      properties: {
+        Id: 17,
+        Name: 'E8 1DN',
+        Abbrev: 'E81DN',
+        Placetype: 'postalcode',
+        Hierarchy: [
+          [ 17 ]
+        ],
+        Centroid: {
+          lat: 12.121212,
+          lon: 21.212121
+        },
+        BoundingBox: 'Feature boundingbox'
+      },
+      geometry: 'Geometry'
+    };
+
+    const extractFields = require('../../../src/pip/components/extractFields').create();
+
+    test_stream([input], extractFields, (err, actual) => {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
+  test.test('abbreviations: postalcode records should use wof:abbreviation otherwise', t => {
+    const input = {
+      properties: {
+        'wof:id': 17,
+        'wof:name': 'E81DN',
+        'wof:abbreviation': 'Feature abbreviation',
+        'wof:placetype': 'postalcode',
+        'wof:hierarchy': [],
+        'geom:latitude': 12.121212,
+        'geom:longitude': 21.212121,
+        'geom:bbox': 'Feature boundingbox'
+      },
+      geometry: 'Geometry'
+    };
+
+    const expected = {
+      properties: {
+        Id: 17,
+        Name: 'E81DN',
+        Abbrev: 'Feature abbreviation',
+        Placetype: 'postalcode',
+        Hierarchy: [
+          [ 17 ]
+        ],
+        Centroid: {
+          lat: 12.121212,
+          lon: 21.212121
+        },
+        BoundingBox: 'Feature boundingbox'
+      },
+      geometry: 'Geometry'
+    };
+
+    const extractFields = require('../../../src/pip/components/extractFields').create();
+
+    test_stream([input], extractFields, (err, actual) => {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
 });


### PR DESCRIPTION
This PR checks to see if a postcode contains whitespace, if it does, then it indexes:

- an abbreviation of the postcode entry which contains no whitespace

Note: this PR is paired with: https://github.com/pelias/whosonfirst/pull/369