### PR TITLE
fix(worker): Remove legacy usage of `temp` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "request": "^2.83.0",
     "simplify-js": "^1.2.1",
     "stable": "^0.1.8",
-    "temp": "^0.8.3",
     "through2": "^3.0.0",
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",
@@ -54,7 +53,8 @@
     "precommit-hook": "^3.0.0",
     "proxyquire": "^2.0.0",
     "tap-dot": "^2.0.0",
-    "tape": "^4.2.2"
+    "tape": "^4.2.2",
+    "temp": "^0.8.3"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
The `temp` package was until recently used in the PIP worker code, but as of https://github.com/pelias/wof-admin-lookup/pull/231 it is no longer needed. Some references to it were missed.

`temp` is now only a dev dependency.