### PR TITLE
feat(layers): Avoid trusting the WOF hierarchy of some layers (notably neighbourhood)

### DIFF
--- a/src/pip/worker.js
+++ b/src/pip/worker.js
@@ -33,10 +33,11 @@ process.on('SIGTERM', () => {
 
 readStream(datapath, layer, localizedAdminNames, (features) => {
   // find all the properties of all features and write them to a file
-  // at the same time, limit the feature.properties to just Id since it's all that's needed in the worker
+  // at the same time, limit the feature.properties to just Id and Hierarchy since it's all that's needed in the worker
   const data = features.reduce((acc, feature) => {
     acc[feature.properties.Id] = feature.properties;
     feature.properties = {
+      Id: feature.properties.Id,
       Hierarchy: feature.properties.Hierarchy
     };
     return acc;

--- a/test/pip/index.js
+++ b/test/pip/index.js
@@ -66,7 +66,7 @@ tape('PiP tests', test => {
 
   });
 
-  test.test('requested lat/lon inside a polygon should return that record\'s hierarchy', t => {
+  test.test('requested lat/lon inside a neighbourhood polygon should return only neighbourhood', t => {
     temp.mkdir('tmp_wof_data', (err, temp_dir) => {
       fs.mkdirSync(path.join(temp_dir, 'data'));
       fs.mkdirSync(path.join(temp_dir, 'meta'));
@@ -138,6 +138,7 @@ tape('PiP tests', test => {
       fs.writeFileSync(path.join(temp_dir, 'data', 'borough_record.geojson'), JSON.stringify(borough_record));
 
       const service = pip.create(temp_dir, ['neighbourhood', 'borough'], false, (err, o) => {
+        // lookup of point that only hits neighbourhood will NOT return borough
         o.lookup(1.5, 1.5, undefined, (err, results) => {
           t.deepEquals(results, [
             {
@@ -149,6 +150,104 @@ tape('PiP tests', test => {
                 lon: 1.5
               },
               BoundingBox: '1,1,2,2',
+              Hierarchy: [ [ 123, 456 ] ]
+            }
+          ]);
+          // must be explicitly ended or the test hangs
+          o.end();
+          t.end();
+        });
+
+      });
+
+    });
+
+  });
+
+  test.test('requested lat/lon inside a neighbourhood and parent borough should return full hierarchy', t => {
+    temp.mkdir('tmp_wof_data', (err, temp_dir) => {
+      fs.mkdirSync(path.join(temp_dir, 'data'));
+      fs.mkdirSync(path.join(temp_dir, 'meta'));
+
+      // write out the WOF meta files with the minimum required fields
+      fs.writeFileSync(
+        path.join(temp_dir, 'meta', 'whosonfirst-data-neighbourhood-latest.csv'),
+        `id,name,path${EOL}123,place name,neighbourhood_record.geojson${EOL}`);
+      fs.writeFileSync(
+        path.join(temp_dir, 'meta', 'whosonfirst-data-borough-latest.csv'),
+        `id,name,path${EOL}456,borough name,borough_record.geojson${EOL}`);
+
+      // setup a neighbourhood WOF record
+      const neighbourhood_record = {
+        id: 123,
+        type: 'Feature',
+        properties: {
+          'geom:bbox': '1,1,4,4',
+          'geom:latitude': 1.5,
+          'geom:longitude': 1.5,
+          'mz:hierarchy_label': 1,
+          'wof:hierarchy': [
+            {
+              locality_id: 123,
+              region_id: 456
+            }
+          ],
+          'wof:id': 123,
+          'wof:name': 'neighbourhood name',
+          'wof:placetype': 'neighbourhood'
+        },
+        geometry: {
+          coordinates: [
+            [
+              [1,1],[4,1],[4,4],[1,4],[1,1]
+            ]
+          ],
+          type: 'Polygon'
+        }
+      };
+
+      // setup a borough WOF record that doesn't contain the lookup point to
+      // show that hierarchy is used to establish the response
+      const borough_record = {
+        id: 456,
+        type: 'Feature',
+        properties: {
+          'geom:bbox': '3,3,4,4',
+          'geom:latitude': 3.5,
+          'geom:longitude': 3.5,
+          'mz:hierarchy_label': 1,
+          'wof:hierarchy': [],
+          'wof:id': 456,
+          'wof:name': 'borough name',
+          'wof:placetype': 'borough'
+        },
+        geometry: {
+          coordinates: [
+            [
+              [3,3],[3,4],[4,4],[4,3],[3,3]
+            ]
+          ],
+          type: 'Polygon'
+        }
+      };
+
+      // and write the records to file
+      fs.writeFileSync(path.join(temp_dir, 'data', 'neighbourhood_record.geojson'), JSON.stringify(neighbourhood_record));
+      fs.writeFileSync(path.join(temp_dir, 'data', 'borough_record.geojson'), JSON.stringify(borough_record));
+
+      const service = pip.create(temp_dir, ['neighbourhood', 'borough'], false, (err, o) => {
+        // lookup of point that only hits neighbourhood will NOT return borough
+        o.lookup(3.5, 3.5, undefined, (err, results) => {
+          t.deepEquals(results, [
+            {
+              Id: 123,
+              Name: 'neighbourhood name',
+              Placetype: 'neighbourhood',
+              Centroid: {
+                lat: 1.5,
+                lon: 1.5
+              },
+              BoundingBox: '1,1,4,4',
               Hierarchy: [ [ 123, 456 ] ]
             },
             {

--- a/test/pip/worker.js
+++ b/test/pip/worker.js
@@ -78,6 +78,7 @@ tape('worker tests', (test) => {
             type: 'results',
             layer: 'test_layer',
             results: {
+              Id: 17,
               Hierarchy: [ [11, 13] ]
             }
           }, 'the hierarchy of the WOF record should be returned');


### PR DESCRIPTION
As measured in #242 and suspected for a long time (see https://github.com/pelias/wof-admin-lookup/issues/156), always trusting the WOF hierarchy for every record can be problematic.

In general, these problems can be fixed, for example the notable case from a few years back where Copenhagen was listed as a city within Sweden rather than Denmark.

However, one particularly bad and common case was neighbourhood boundaries. Many neighbourhood records have geometries that were estimated using Foursquare checkin data. They often encompass a very wide area. While the parent locality of all of these neighbourhoods might be generally correct, it's often possible for large areas to be incorrectly assigned a locality, region, or even country based merely on the neighbourhood.

This PR changes the logic for admin lookup to attempt to mitigate this problem.

As before, admin lookup starts at the "lowest" layer. However, previously, any match at any layer resulted in trusting that match's hierarchy completely. There are now _two_ cases:

1.) "untrusted" layers (currently `neighbourhood`): Save that layer's data for later use, but ignore its hierarchy, and continue on searching up the list of layers as if there has been a miss
2.) All other layers: use the heierarchy from the record as before, but use any saved data about untrusted layers to re-construct a full hierarchy before returning a result.

In testing, this essentially completely solves the issue of neighbourhoods in Australia, where it's particularly bad. As @NickStallman estimated, we now match about 96% of the time with the locality information from G-NAF. The remaining 4% is mostly areas where WOF data is clearly missing, and can (hopefully) be easily added, bringing the success rate essentially to 100%.