### PR TITLE
fix(pip): Avoid querying non-existent layer

### DIFF
--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -216,7 +216,7 @@ function handleResults(msg) {
       }
 
       // continue search if there are more layers. Otherwise return full hierarchy
-      if (responseQueue[msg.id].search_layers !== 0) {
+      if (responseQueue[msg.id].search_layers.length !== 0) {
         searchWorker(msg.id);
       } else {
         // assemble full hierarchy and return


### PR DESCRIPTION
https://github.com/pelias/wof-admin-lookup/pull/246 introduced a bug where a query that specified layers to search could cause the PIP service or admin lookup to crash.