### PR TITLE
feat(logger): Use warning for invalid value messages

### DIFF
--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -58,7 +58,7 @@ function createPipResolverStream(pipResolver, config) {
 
           }
           catch (err) {
-            logger.info('invalid value', {
+            logger.warn('invalid value', {
               centroid: doc.getCentroid(),
               result: {
                 type: placetype,

--- a/src/usePostalCity.js
+++ b/src/usePostalCity.js
@@ -71,7 +71,7 @@ function usePostalCity( result, doc ){
     });
   }
   catch (err) {
-    logger.info('invalid value', {
+    logger.warn('invalid value', {
       centroid: doc.getCentroid(),
       result: {
         type: 'locality',


### PR DESCRIPTION
These are non-fatal error conditions that don't necessarily represent a true problem, so warning feels like the right level.

Leaving them at the `info` level also makes it harder to visually scan for progress output from the importers.