### PR TITLE
fix(postalCities): Do not assign a parent that is already there

### DIFF
--- a/src/usePostalCity.js
+++ b/src/usePostalCity.js
@@ -1,4 +1,4 @@
-
+const _ = require('lodash');
 const peliasLogger = require('pelias-logger');
 const logger = peliasLogger.get('wof-admin-lookup');
 const postalCityMap = require('./postalCityMap');
@@ -31,6 +31,10 @@ function usePostalCity( result, doc ){
 
   // check the localities list is valid
   if( !Array.isArray(localities) || !localities.length ){ return; }
+
+  // check if the locality ids is already in _any_ of the parent id fields
+  const locality_ids = localities.map(locality => locality.wofid);
+  if (_.intersection(getParentIDs(doc), locality_ids).length > 0) { return; }
 
   // we will use the first value instead of the PIP locality
   try {
@@ -79,6 +83,11 @@ function usePostalCity( result, doc ){
       }
     });
   }
+}
+
+function getParentIDs(doc) {
+  const ids = Object.keys(doc.parent).filter(key => key.match(/_id$/)).map(key => doc.parent[key]);
+  return _.flatten(ids);
 }
 
 function getPostalCode(doc){


### PR DESCRIPTION
Our postal cities code originally from https://github.com/pelias/wof-admin-lookup/pull/232 can cause multiple parent IDs to end up the same.

In practice, how this ends up working is with `borough` placetypes, where the postal cities code assigns a `borough` ID to the `locality_id` parent field.

This is problematic for two reasons:

1. It causes the resulting `locality_gid` property returned by the Pelias API to be incorrect
2. It creates incorrect labels in areas with boroughs, like NYC. An example is a label changing from `132 Dean Street, Brooklyn, New York, NY, USA` to `132 Dean Street, Brooklyn, Brooklyn, NY, USA`

This change ensures that there can't be any duplicate IDs created in this way, which should solve both the particular problem mentioned here, as well as others we might find in the future.