### PR TITLE
Revert duplicate id protection

### DIFF
--- a/src/usePostalCity.js
+++ b/src/usePostalCity.js
@@ -50,13 +50,6 @@ function updateParentProperty(doc, placetype, allAlternatives){
   // ensure that there is at least one alternative for this placetype
   if( !_.isArray(alternatives) || _.isEmpty(alternatives) ){ return; }
 
-  // abort if the postal cities ids are already in _any_ of the parent id fields
-  const alternative_ids = alternatives.map(alternative => alternative.wofid);
-  if (_.intersection(getParentIDs(doc), alternative_ids).length > 0) { return; }
-
-  // we will use the first postal cities value as the 'primary' value for name/id/abbr.
-  // all other values will be added as 'aliases'.
-  // if a value was already set from PIP it will be converted to an alias and preserved.
   try {
 
     // save the existing placetype as an alias
@@ -107,11 +100,6 @@ function updateParentProperty(doc, placetype, allAlternatives){
       }
     });
   }
-}
-
-function getParentIDs(doc) {
-  const ids = Object.keys(doc.parent).filter(key => key.match(/_id$/)).map(key => doc.parent[key]);
-  return _.flatten(ids);
 }
 
 function getPostalCode(doc){

--- a/test/lookupStreamPostalCityTest.js
+++ b/test/lookupStreamPostalCityTest.js
@@ -43,6 +43,39 @@ tape('tests', (test) => {
     });
   });
 
+  test.test('postal cities - USA lookup - ZIP 21236 (Perry Hall, MD)', (t) => {
+    const inputDoc = new Document( 'whosonfirst', 'placetype', '1')
+      .setCentroid({ lat: 12.121212, lon: 21.212121 })
+      .setAddress('zip', '21236');
+
+    const expectedDoc = new Document( 'whosonfirst', 'placetype', '1')
+      .setCentroid({ lat: 12.121212, lon: 21.212121 })
+      .addParent( 'country', 'United States', '1', 'USA')
+      .addParent( 'locality', 'Nottingham', '1125996559')
+      .addParent( 'locality', 'Baltimore', '85949461')
+      .addParent( 'locality', 'Perry Hall', '85950213')
+      .addParent( 'locality', 'White Marsh', '85950229')
+      .setAddress('zip', '21236');
+
+    const resolver = {
+      lookup: (centroid, search_layers, callback) => {
+        const result = {
+          country: [ {id: 1, name: 'United States', abbr: 'USA'} ],
+          locality: [ {id: '85950213', name: 'Perry Hall'} ]
+        };
+        setTimeout(callback, 0, null, result);
+      }
+    };
+
+    const lookupStream = stream(resolver, {usePostalCities: true});
+    t.doesNotThrow(() => {
+      test_stream([inputDoc], lookupStream, (err, actual) => {
+        t.deepEqual(actual, [expectedDoc], 'locality should be replaced with postal city');
+        t.end();
+      });
+    });
+  });
+
   test.test('postal cities - USA lookup - ZIP 11238 (Brooklyn)', (t) => {
     const inputDoc = new Document( 'whosonfirst', 'placetype', '3')
       .setCentroid({ lat: 12.121212, lon: 21.212121 })


### PR DESCRIPTION
This protection was too conservative, and would cause many records to not benefit from postal cities data.

A new test case for one of those situations is included, which now passes with this change and https://github.com/pelias/wof-admin-lookup/pull/282

_This PR includes #282 and will be rebased once it's merged_
