### PR TITLE
chore(CI): Remove deprecated `matrix` section of Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ notifications:
 node_js:
   - 10
   - 12
-matrix:
-  fast_finish: true
 script: npm run travis
 before_install:
   - npm i -g npm


### PR DESCRIPTION
Travis seems to have a new feature to validate build config.

The validation for recent builds (https://travis-ci.org/pelias/wof-admin-lookup/builds/649254913/config) shows that some config options are being missed, such as semantic release, due to the new way Travis is parsing our config.

This should fix it.