### PR TITLE
Supports for multiple databases

### DIFF
--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -46,9 +46,9 @@ module.exports.create = function createPIPService(datapath, layers, localizedAdm
   layers = _.intersection(defaultLayers, _.isEmpty(layers) ? defaultLayers : layers);
 
   if (isSqlite === true) {
-    const filename = path.join(datapath, 'sqlite', 'whosonfirst-data-latest.db');
-    if (!fs.existsSync(filename)) {
-      return callback(`unable to locate sqlite file ${filename}`);
+    const folder = path.join(datapath, 'sqlite');
+    if (!fs.existsSync(folder)) {
+      return callback(`unable to locate sqlite folder`);
     }
   } else {
     // keep track of any missing metafiles for later reporting and error conditions


### PR DESCRIPTION
## Background

WOF database will be hosted on [geocode.earth](https://geocode.earth/data/whosonfirst), per country will be available, so the code should support per country databases too.

## What's new ?

Now, wof admin lookup will combine all databases like `whosonfirst-data-[a-z0-9-]+\.db` that means both global and per country databases.

related: pelias/whosonfirst#460  pelias/whosonfirst#469  pelias/whosonfirst#477