### PR TITLE
gracefully handle shutting down workers before the service has finished instantiating

### DIFF
--- a/src/localPipResolver.js
+++ b/src/localPipResolver.js
@@ -2,6 +2,7 @@
 
 const logger = require('pelias-logger').get('wof-admin-lookup');
 const createPipService = require('./pip/index').create;
+const killAllWorkers = require('./pip/index').killAllWorkers;
 const _ = require('lodash');
 
 /**
@@ -19,7 +20,6 @@ function LocalPipService(datapath, layers) {
     }
     self.pipService = service;
   });
-
 }
 
 /**
@@ -76,6 +76,13 @@ LocalPipService.prototype.end = function end() {
   if (this.pipService) {
     logger.info('Shutting down admin lookup service');
     this.pipService.end();
+  } else {
+    /**
+     * this is required to handle the case where the '$this.pipService'
+     * variable is not available yet but the stream has ended and needs to
+     * terminate all workers, such as when the stream input is /dev/null.
+    */
+    killAllWorkers();
   }
 };
 

--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -5,8 +5,6 @@
  * functions for initializing them and searching them.
  */
 
-'use strict';
-
 const path = require('path');
 const childProcess = require( 'child_process' );
 const logger = require( 'pelias-logger' ).get( 'wof-pip-service:master' );
@@ -134,6 +132,7 @@ module.exports.create = function createPIPService(datapath, layers, localizedAdm
 function killAllWorkers() {
   _.values(workers).forEach(worker => worker.kill());
 }
+module.exports.killAllWorkers = killAllWorkers;
 
 function startWorker(datapath, layer, localizedAdminNames, callback) {
   const worker = childProcess.fork(path.join(__dirname, 'worker'), [layer, datapath, localizedAdminNames]);


### PR DESCRIPTION
bugfix for issue highlighted in https://github.com/pelias/polylines/issues/245

When the stream is `/dev/null` then there is a case for prematurely shutting down all worker nodes since they will not be required.
As the code currently stands, this case is ignored and so the workers all remain running, which hangs the process.

Since this code is likely to be removed this year I didn't invest any time in refactoring the synchronous assignment of `$this.pipService`, instead I simply exposed an interface that can enumerate the workers and kill them.