### PR TITLE
Only change locality if borough is _not_ changed

### DIFF
--- a/src/usePostalCity.js
+++ b/src/usePostalCity.js
@@ -38,8 +38,10 @@ function usePostalCity( result, doc ){
   // 11225	85977539	New York	NYC	locality	1
 
   // select which placetypes to consider for replacement
-  updateParentProperty(doc, 'locality', alternatives);
-  updateParentProperty(doc, 'borough', alternatives);
+  const changedBorough = updateParentProperty(doc, 'borough', alternatives);
+  if (!changedBorough) {
+    updateParentProperty(doc, 'locality', alternatives);
+  }
 }
 
 function updateParentProperty(doc, placetype, allAlternatives){
@@ -48,7 +50,7 @@ function updateParentProperty(doc, placetype, allAlternatives){
   var alternatives = allAlternatives.filter(a => a.placetype === placetype);
 
   // ensure that there is at least one alternative for this placetype
-  if( !_.isArray(alternatives) || _.isEmpty(alternatives) ){ return; }
+  if( !_.isArray(alternatives) || _.isEmpty(alternatives) ){ return false; }
 
   try {
 
@@ -90,6 +92,9 @@ function updateParentProperty(doc, placetype, allAlternatives){
       // note: addParent can throw an error if, for example, name is an empty string
       doc.addParent(placetype, alternative.name, alternative.wofid, alternative.abbr);
     });
+
+    // return true if record was changed
+    return true;
   }
   catch (err) {
     logger.warn('invalid value', {


### PR DESCRIPTION
Because we now manage postal cities replacements for both borough and locality values, we have to be a bit careful about when we replace each of them.

After investigating what looked like an error in our logic for determining the best postal cities match in
https://github.com/pelias/wof-admin-lookup/issues/288, it turns out a significant issue we were seeing in Brooklyn was actually a more subtle bug.

In short, it looks like if we replace the borough field with with a postal city value, we should _not_ replace the locality value.

Closes #288