### PR TITLE
RFC: optionally perform multiple PIP lookups per doc

### DIFF
--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const async = require('async');
 const parallelTransform = require('parallel-transform');
 const logger = require( 'pelias-logger' ).get( 'wof-admin-lookup' );
 const getAdminLayers = require( './getAdminLayers' );
@@ -10,6 +11,51 @@ function hasAnyMultiples(result) {
   });
 }
 
+function updateDocument(doc, config, point, result) {
+  // log results w/o country OR any multiples
+  if (_.isEmpty(result.country)) {
+    logger.debug('no country', {
+      centroid: point,
+      result: result
+    });
+  }
+  if (hasAnyMultiples(result)) {
+    logger.debug('multiple values', {
+      centroid: point,
+      result: result
+    });
+  }
+
+  doc.getParentFields()
+    // filter out placetypes for which there are no values
+    .filter((placetype) => { return !_.isEmpty(result[placetype]); })
+    // assign parents into the doc
+    .forEach((placetype) => {
+      const values = result[placetype];
+
+      try {
+        // addParent can throw an error if, for example, name is an empty string
+        doc.addParent(placetype, values[0].name, values[0].id.toString(), values[0].abbr);
+
+      }
+      catch (err) {
+        logger.warn('invalid value', {
+          centroid: point,
+          result: {
+            type: placetype,
+            values: values
+          }
+        });
+      }
+    });
+
+  // prefer a 'postal city' locality when a valid postal code is available
+  // optionally enable/disable this functionality using config variable.
+  if (config && true === config.usePostalCities) {
+    usePostalCity(result, doc);
+  }
+}
+
 function createPipResolverStream(pipResolver, config) {
   return function (doc, callback) {
     // don't do anything if there's no centroid
@@ -17,65 +63,45 @@ function createPipResolverStream(pipResolver, config) {
       return callback(null, doc);
     }
 
-    pipResolver.lookup(doc.getCentroid(), getAdminLayers(doc.getLayer()), (err, result) => {
-      if (err) {
-        // if there's an error, just log it and move on
-        logger.error(`PIP server failed: ${(err.message || JSON.stringify(err))}`, {
-          id: doc.getGid(),
-          lat: doc.getCentroid().lat,
-          lon: doc.getCentroid().lon
+    let points = [doc.getCentroid()];
+    const layers = getAdminLayers(doc.getLayer());
+
+    // optionally, perform multiple lookups per document if additional
+    //  points are specified in the 'pip' $meta property.
+    const pip = doc.getMeta('pip');
+    if( _.isArray(pip) && !_.isEmpty(pip) ){
+      points = points.concat(
+        pip.filter(point => {
+          return _.isPlainObject(point) && _.has(point, 'lon') && _.has(point, 'lat');
+        })
+      );
+    }
+
+    var lookups = points.map(point => {
+      return (cb) => {
+        pipResolver.lookup(point, layers, (err, result) => {
+          if (err) {
+            // if there's an error, just log it and move on
+            logger.error(`PIP server failed: ${(err.message || JSON.stringify(err))}`, {
+              id: doc.getGid(),
+              lat: point.lat,
+              lon: point.lon
+            });
+            // don't pass the unmodified doc along
+            return cb(err);
+          }
+
+          updateDocument(doc, config, point, result);
+          cb();
         });
-        // don't pass the unmodified doc along
+      };
+    });
+
+    async.parallel(lookups, (err) => {
+      if (err) {
         return callback();
       }
-
-      // log results w/o country OR any multiples
-      if (_.isEmpty(result.country)) {
-        logger.debug('no country', {
-          centroid: doc.getCentroid(),
-          result: result
-        });
-      }
-      if (hasAnyMultiples(result)) {
-        logger.debug('multiple values', {
-          centroid: doc.getCentroid(),
-          result: result
-        });
-      }
-
-      doc.getParentFields()
-        // filter out placetypes for which there are no values
-        .filter((placetype) => { return !_.isEmpty(result[placetype]); } )
-        // assign parents into the doc
-        .forEach((placetype) => {
-          const values = result[placetype];
-
-          try {
-            // addParent can throw an error if, for example, name is an empty string
-            doc.addParent(placetype, values[0].name, values[0].id.toString(), values[0].abbr);
-
-          }
-          catch (err) {
-            logger.warn('invalid value', {
-              centroid: doc.getCentroid(),
-              result: {
-                type: placetype,
-                values: values
-              }
-            });
-          }
-
-        }
-      );
-
-      // prefer a 'postal city' locality when a valid postal code is available
-      // optionally enable/disable this functionality using config variable.
-      if( config && true === config.usePostalCities ){
-        usePostalCity( result, doc );
-      }
-
       callback(null, doc);
-
     });
   };
 }


### PR DESCRIPTION
Hi @orangejulius, @Joxit, @blackmad 

I had a thought last night that we can fairly easily improve recall for queries where the user enters the name of a nearby parent, instead of the parent assigned by PIP. ie. they get the neighbourhood wrong.

We already have the postal cities mapping, which works well when a postcode is present.
The postal cities mapping adds aliases to the parent field, so a record can have multiple 'neighbourhood' values, for instance.

We can extend on this further by performing *multiple* point-in-polygon lookups per document and recording each of the additionally matched parents as an alias.

I threw this PR together quickly, so it's not exactly what I would recommend merging, but I wanted to solicit feedback on the general idea, which is:

- use the `doc.getCentroid()` for the primary parent info
- if there is a 'meta' property specified with additional points, use results from those lookups for aliases of the parent.

The `wof-admin-lookup` module would not be responsible for determining *which* additional points to use, we can update the importers accordingly to use this functionality as required, varying the amount of points based on geometry type and layer.

- I think we can begin with adding *two additional points* to the `polyline` importer, so we PIP the start and end points of a street additionally to the midpoint
- We may also want to apply this logic to some of the "lower level" WOF records, such as neighbourhoods. We could provide *four additional points* at the corners of the bbox, or even extend this to the 8 compass directions.
- Finally we *may* want to also apply this to points using a similar method, this would greatly improve the 'postal cities' and 'realestate cities' issues at the cost of significantly more PIP work.

Below is a pretty picture I drew to illustrate how this might work for `point`, `linestring` and `polygon` geometry types, in each case the poorly draw pin is the centroid we're currently using and the crosshairs highlighted in yellow represent *additional* points we might lookup for aliases

![IMG_20200909_095004_2](https://user-images.githubusercontent.com/738069/92572330-948b8d80-f284-11ea-808e-bfa53158c6fb.jpg)
