### PR TITLE
NZ postal cities map no longer required

### DIFF
--- a/src/postalCityMap.js
+++ b/src/postalCityMap.js
@@ -58,7 +58,6 @@ const tables = {
   'USA': loadTable('USA'), // Unites States of America
   'VIR': loadTable('VIR'), // United States Virgin Islands
   'NLD': loadTable('NLD'), // The Netherlands
-  'NZL': loadTable('NZL')  // New Zealand
 };
 
 // load the file format in to memory


### PR DESCRIPTION
since WOF imported the [NZ fire and emergency localities](https://data.linz.govt.nz/layer/104830-fire-and-emergency-nz-localities/) file to the `locality` placetype the NZ postal cities mapping is both wrong and not really required.

that LINZ dataset provides very good locality mapping across NZ, so it's unlikely that the postal cities mapping is more accurate than the result returned from PIP.

Some quick background, in NZ there was recently a bit of a shift in how localities are defined in WOF.
What 🥝 call a 'Suburb' is now a locality (previously a `neighbourhood`) and the "city proper" is now a `County` (previously a `locality`).

tl;dr the current file is broken and not really required, we *could* regenerate it but it's probably not worth it.

I would consider re-generating the NZ file at a later date if it can be show to produce better results, but for now it's out-of-date, eg: `8042->Christchurch` (previously a polygon, now a point) when the PIP result is `Hei Hei` (a polygon), both in the `locality` placetype.