### PR TITLE
Enable postalcode lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Who's On First Admin Lookup module recognizes the following top-level properties
 {
   "imports": {
     "adminLookup": {
-      "enabled": true
+      "enabled": true,
+      "lookupPostalCodes": false
     },
     "whosonfirst": {
       "datapath": "/path/to/wof-data"
@@ -119,6 +120,8 @@ The `weight` field is used to determine which entry is the most important, this 
 #### Configuration
 
 To enable the postal cities functionality, set `imports.adminLookup.usePostalCities` to `true` in your `pelias.json` file.
+
+To enable the lookup of postalcodes, set `imports.adminLookup.lookupPostalCodes` to `true` in your `pelias.json` file. Because postal code data can amount to a significant size, this setting is disabled by default.
 
 #### Advanced Configuration
 

--- a/schema.js
+++ b/schema.js
@@ -9,6 +9,7 @@ module.exports = Joi.object().keys({
       enabled: Joi.boolean().default(true),
       missingMetafilesAreFatal: Joi.boolean().default(false),
       usePostalCities: Joi.boolean().default(false),
+      lookupPostalCodes: Joi.boolean().default(false),
       postalCitiesDataPath: Joi.string()
     }).unknown(true),
     whosonfirst: Joi.object().keys({

--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -11,7 +11,9 @@ const logger = require( 'pelias-logger' ).get( 'wof-pip-service:master' );
 const async = require('async');
 const _ = require('lodash');
 const fs = require('fs');
-const missingMetafilesAreFatal = require('pelias-config').generate(require('../../schema')).imports.adminLookup.missingMetafilesAreFatal;
+const config = require('pelias-config').generate(require('../../schema')).imports.adminLookup;
+const missingMetafilesAreFatal = config.missingMetafilesAreFatal;
+const lookupPostalCodes = config.lookupPostalCodes;
 
 let requestCount = 0;
 // worker processes keyed on layer
@@ -22,6 +24,7 @@ const wofData = {};
 
 const defaultLayers = [
   'neighbourhood',
+  ...(lookupPostalCodes ? ['postalcode'] : []),
   'borough',
   'locality',
   'localadmin',
@@ -184,8 +187,8 @@ function handleResults(msg) {
     }
 
   } else {
-    // there was a hit, so find the hierachy and assemble all the pieces
-    const untrustedLayers = ['neighbourhood'];
+    // there was a hit, so find the hierarchy and assemble all the pieces
+    const untrustedLayers = ['neighbourhood', 'postalcode'];
 
     if (untrustedLayers.includes(msg.layer)) {
       // push _only_ the first layers results onto the hierarchy

--- a/src/service/PointInPolygon.js
+++ b/src/service/PointInPolygon.js
@@ -7,7 +7,7 @@ const ServiceConfiguration = require('pelias-microservice-wrapper').ServiceConfi
 
 // allow searching only against land layers, or a filtered subset of land layers
 function calculateLayers(inputLayers) {
-  const allowedLayers = [ 'neighbourhood', 'borough', 'locality', 'localadmin', 'county',
+  const allowedLayers = [ 'neighbourhood', 'postalcode', 'borough', 'locality', 'localadmin', 'county',
     'macrocounty', 'region', 'macroregion', 'dependency', 'country' ];
 
   // if no input layers are specified, return all of the allowed layers

--- a/test/remotePipResolverTest.js
+++ b/test/remotePipResolverTest.js
@@ -6,7 +6,7 @@ const nock = require('nock');
 const remotePipResolver = require('../src/remotePipResolver');
 
 // helper var for enumberating all the layer parameters sent in all queries
-const layers = [ 'neighbourhood', 'borough', 'locality', 'localadmin', 'county',
+const layers = [ 'neighbourhood', 'postalcode', 'borough', 'locality', 'localadmin', 'county',
                         'macrocounty', 'region', 'macroregion', 'dependency', 'country' ];
 
 tape('tests', (test) => {

--- a/test/service/PointInPolygon.js
+++ b/test/service/PointInPolygon.js
@@ -36,7 +36,7 @@ tape('PointInPolygon service configuration tests', (test) => {
     const pointInPolygon = new PointInPolygon(config);
 
     const expectedParams = {
-      layers: [ 'neighbourhood', 'borough', 'locality', 'localadmin', 'county',
+      layers: [ 'neighbourhood', 'postalcode', 'borough', 'locality', 'localadmin', 'county',
                 'macrocounty', 'region', 'macroregion', 'dependency', 'country' ]
     };
 


### PR DESCRIPTION
:wave: I did some work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

Currently `wof-admin-lookup` does not support lookups in the `postalcode` layer.

---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->
This diff enables lookup in the `postalcode` layer, guarded by a config flag. Because the postal code data can amount to a significant size (~12.6 GB for the global postalcode dataset as of today), this setting is disabled by default.

The new `lookupPostalCode` setting affects only the "local resolver" mode. If it's set to true, it will start the `postalcode` layer worker. The layer is considered "untrusted", just like the `neighbourhood` layer.

---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->

I've tested this diff locally by using [pip-service](https://github.com/pelias/pip-service):
* link `pip` with the local `wof-admin-lookup` version by running:
  * `npm link` in the `wof-admin-lookup` folder
  * `npm link  pelias-wof-admin-lookup` in the `pip-service` folder
* download a WOF postal code dataset and place it in the `pip-service/sqlite` (I used France, as well as the  "latest" sqlite from https://geocode.earth/data/whosonfirst/)
* set `imports.adminLookup.lookupPostalCodes` to `true` in `pelias.json`, then start PIP
* query for the `postalcode` layer: http://localhost:3102/2.2441473904672127/48.9052128712992?layers=postalcode

On my machine, the entire global postal code dataset was loaded in ~6 minutes:
```
2022-02-08T11:23:05.820Z - info: [wof-pip-service:master] postalcode worker loaded 421118 features in 370.922 seconds
2022-02-08T11:23:06.440Z - info: [wof-pip-service:master] PIP Service Loading Completed!!!
```