### PR TITLE
Use 3-character country code for dependencies where possible

### DIFF
--- a/src/pip/components/extractFields.js
+++ b/src/pip/components/extractFields.js
@@ -41,14 +41,7 @@ module.exports.create = function(enableLocalizedNames) {
       res.properties.Hierarchy = [ [ res.properties.Id ] ];
     }
 
-    // use different abbreviation field for country
-    if (res.properties.Placetype === 'country') {
-      res.properties.Abbrev = wofData.properties['wof:country_alpha3'];
-    } else if(wofData.properties['wof:shortcode']) {
-      res.properties.Abbrev = wofData.properties['wof:shortcode'];
-    } else {
-      res.properties.Abbrev = wofData.properties['wof:abbreviation'];
-    }
+    res.properties.Abbrev = getAbbreviation(wofData);
 
     return res;
   });
@@ -67,6 +60,30 @@ function getName(wofData, enableLocalizedNames) {
   }
   return getDefaultName(wofData);
 }
+
+/*
+ * Return an abbreviation based on the first defined value across several fields
+ */
+function getAbbreviation(wofData) {
+  const props = wofData.properties;
+  const placetype = props['wof:placetype'];
+
+  // countries have additional properties to check that
+  // may contain 3-character codes
+  if (['country', 'dependency'].includes(placetype)) {
+    return props['wof:country_alpha3'] ||
+      props['qs:adm0_a3'] ||
+      props['ne:adm0_a3'] ||
+      //the following properties generally contain a 2-character codes
+      //instead of 3 character and are therefore not preferred
+      props['wof:shortcode'] ||
+      props['wof:abbreviation'];
+   } else {
+    return props['wof:shortcode'] ||
+      props['wof:abbreviation'];
+   }
+}
+
 
 /**
  * Get the string value of the property or false if not found

--- a/test/pip/components/extractFieldsTest.js
+++ b/test/pip/components/extractFieldsTest.js
@@ -284,6 +284,48 @@ tape('extractFields tests', function(test) {
 
   });
 
+  test.test('dependency placetype should check additional fields for 3 character country code', function(t) {
+    var input = {
+      properties: {}
+    };
+    input.properties['wof:id'] = 20;
+    input.properties['wof:name'] = 'Dependency name';
+    input.properties['wof:country_alpha3'] = undefined; // this is not always available for dependencies
+    input.properties['qs:adm0_a3'] = 'GUM'; // Quattroshapes or Natural Earth generally do provide a 3 char code
+    input.properties['wof:placetype'] = 'dependency';
+    input.properties['wof:hierarchy'] = [
+      {
+        placetype1: 12,
+        placetype2: 34
+      }
+    ];
+
+    var expected = {
+      properties: {
+        Id: 20,
+        Name: 'Dependency name',
+        Abbrev: 'GUM',
+        Placetype: 'dependency',
+        Hierarchy: [
+          [ 12, 34 ]
+        ],
+        Centroid: {
+          lat: undefined,
+          lon: undefined
+        },
+        BoundingBox: undefined
+      },
+      geometry: undefined
+    };
+
+    var extractFields = require('../../../src/pip/components/extractFields').create();
+
+    test_stream([input], extractFields, function(err, actual) {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+  });
+
   test.test('when available, wof:label should be used instead of wof:name', function(t) {
     var input = {
       properties: {}


### PR DESCRIPTION
After https://github.com/pelias/api/pull/1622, which extends the `boundary.country` API parameter to include the `dependency` placetype, we noticed that venue and address records often have a 2-character country code when they are part of a dependency.

The `boundary.country` parameter currently checks only for 3-character codes, and so the best solution is to ensure the relevant property on all records in Elasticsearch is a 3-character country code whenever possible.

This change expands on the logic for selecting an abbreviation for an admin record to be used for point in polygon lookup. Logic specific to countries is expanded to include dependencies, and some additional possible fields that might contain 3-character codes are checked.

Because the abbreviation logic is now a bit more substantial, it's extracted into its own function. It's also been made a bit less redundant and hopefully more clear.