### PR TITLE
ensure parent endonyms exist for all countries and megacities

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,7 @@
   "node": true,
   "curly": true,
   "eqeqeq": true,
-  "esversion": 6,
+  "esversion": 9,
   "freeze": true,
   "immed": true,
   "indent": 2,

--- a/schema.js
+++ b/schema.js
@@ -9,7 +9,8 @@ module.exports = Joi.object().keys({
       enabled: Joi.boolean().default(true),
       missingMetafilesAreFatal: Joi.boolean().default(false),
       usePostalCities: Joi.boolean().default(false),
-      postalCitiesDataPath: Joi.string()
+      postalCitiesDataPath: Joi.string(),
+      useEndonyms: Joi.boolean().default(false)
     }).unknown(true),
     whosonfirst: Joi.object().keys({
       datapath: Joi.string().required(),

--- a/src/data/aliases/country-endonyms.psv
+++ b/src/data/aliases/country-endonyms.psv
@@ -1,0 +1,202 @@
+85632509|Philippines|República de Filipinas
+85633051|Schweiz|Schwyz|Suisse|Svizzera
+85633293|México
+85633745|România
+85632343|Andorra
+85633143|Finland|Suomi
+85632757|Guiné-Bissau
+85633105|Česko
+85632793|Australia
+85632573|الامارات
+85633279|Latvija
+85633341|Noreg|Norge
+85632755|Fiji|Viti
+85632191|العراق
+85632627|ليبيا
+85633763|San Marino
+85632295|Aruba
+85632679|موريتانيا‎
+85633739|فلسطين
+85632513|Тоҷикистон
+85632465|नेपाल
+85632431|Federated States of Micronesia
+85632749|Brunei
+85633285|Monaco
+102312305|Organización de las Naciones Unidas|United Nations|Организация Объединённых Наций|الأمم المتحدة
+85633345|Aotearoa|New Zealand
+85632623|Bolivia|Puliwya|Wuliwya
+85632365|Senegaal|Sénégal
+85633331|Malta
+85633249|Ísland
+85632433|Ayiti|Haïti
+85632235|Botswana
+85632455|Tonga
+85632241|ປະເທດລາວ
+85632405|Shqipëria
+85632661|Seychelles
+85632703|Tunisie|تونس
+85632591|Solomon Islands
+85632765|São Tomé e Príncipe
+85632179|Panamá
+85632215|Jamaica
+85632339|The Bahamas
+85632671|Türkmenistan
+85632207|عمان
+85632593|Jersey
+85632609|Bosna i Hercegovina|Босна и Херцеговина
+85632253|السعودية
+85632529|Antigua and Barbuda
+85632303|Rwanda
+85632483|Hong Kong S.A.R.|香港
+85632229|افغانستان
+85633253|Italia
+85632499|اليمن
+85632383|Malawi|Malaŵi
+85632401|الكويت
+85632583|Timor-Leste|Timór Lorosa'e
+85632305|ދިވެހިރާއްޖެ
+85633121|Danmark
+85632379|Soomaaliya|الصومال‎
+85632393|Türkiye
+85633789|Sverige
+85632245|Cameroon|Cameroun
+85633111|Deutschland
+85632511|Uruguay
+85632521|Perú|Piruw
+85632271|Trinidad and Tobago
+85633267|Liachtaschta|Liechtenstein
+85632347|Papua New Guinea|Papua Niugini
+85632185|Sint Maarten|Sint Maarten (land)
+85632313|இலங்கை|ශ්‍රී ලංකාව
+85632545|El Salvador
+85632997|Belgien|Belgique|België
+85633237|Magyarország
+85632761|Киргизия|Кыргызстан
+85632167|البحرين
+85632249|Liberia
+85632285|Burundi|Uburundi
+85632359|ព្រះរាជាណាចក្រកម្ពុជា
+85632325|Tchad|تشاد
+85632259|Comores|جزر القمر
+85632551|Saint Kitts and Nevis
+85632647|Togo
+85632643|République démocratique du Congo
+85632173|Lesotho
+85632227|Tanzania
+85632391|Ködörösêse tî Bêafrîka|République centrafricaine
+85632713|República Dominicana
+85632635|Umbuso weSwatini|eSwatini
+85633813|South Africa
+85632451|Algérie|الجزائر
+85632541|République du Congo
+85632729|Moçambique
+85632625|Uganda
+85632559|Zambia
+85632261|Ecuador|Ikwadur
+85632535|Namibia|Namibië
+85632243|Zimbabwe
+85632189|Ghana
+85633135|Eesti
+85632203|Indonesia
+85632605|Singapore|Singapura|சிங்கப்பூர்|新加坡
+85632269|Niger
+85632781|Eritrea|إريتريا|ኤርትራ
+85632281|Angola
+85633723|Polska
+85632603|The Gambia
+85632691|Guinée
+85632735|Nigeria|Nàìjíríà
+85632287|Guinea Ecuatorial|Guinée équatoriale
+85632331|Belau|Palau
+85632299|قطر
+85632355|Paraguay|Paraguái
+85632257|ኢትዮጵያ
+85632599|Nicaragua
+85632645|Oʻzbekiston
+85633337|Nederland
+85632161|Macau|澳门
+85632441|Curaçao|Pais Kòrsou
+85632681|Samoa|Sāmoa
+85632263|Ripablik blong Vanuatu|Vanuatu
+85632439|Монгол улс
+85632675|Cuba
+85632763|Việt Nam
+85632181|မြန်မာနိုင်ငံ
+85632467|Sierra Leone
+85632487|Costa Rica
+85632785|Österreich
+85633769|Slovensko
+85632223|Madagascar|Madagasikara
+85632569|Saint Vincent and the Grenadines
+85632663|Majõl|Marshall Islands
+85633259|Kosova|Република Косово
+85632429|日本
+85632213|Burkina Faso
+85633269|Lietuva
+85632319|Djibouti|جيبوتي
+85632475|বাংলাদেশ
+85633041|Canada
+85633793|United States
+85633171|Ελλάδα
+85633001|България
+85632667|Црна Гора
+85633159|United Kingdom
+85632397|Guyana
+85632639|조선민주주의인민공화국
+85632693|Maroc|المغرب
+85632361|ایران
+85632425|الأردن
+85632773|Հայաստան
+85632751|Sudan|السودان
+85632533|لبنان
+85632171|འབྲུག་ཡུལ་
+85632307|Казахстан|Қазақстан
+85632323|Honduras
+85632657|South Sudan
+85632407|Gabon
+85633009|Brasil
+85633147|France
+85632685|Россия
+85632231|한국
+85632717|Azərbaycan
+85633287|Republica Moldova
+85633163|Sakartvelo
+85632571|Belize
+85632329|Kenya
+85632413|Syrie|سوريا
+85632247|Bénin
+85633805|Украина|Україна
+85632659|Pakistan|پاکستان
+85632581|مصر
+85632315|ישראל|إسرائيل
+85633217|Kalaallit Nunaat
+85632505|Argentina
+85632385|Guatemala
+85633735|Portugal
+85633129|España
+85632469|India|भारत
+85632317|Venezuela
+85632519|Colombia
+85632373|Македонија
+85632449|Côte d'Ivoire
+85632437|Kıbrıs Cumhuriyeti|Κύπρος
+85632747|Naoero|Nauru
+85632491|Barbados
+85632443|Suriname
+85632503|Dominica
+85632357|Maurice|Mauritius
+85632335|Grenada
+85632369|St. Lucia
+85632607|Tuvalu
+85632709|Kiribati|Ribaberiki Kiribati
+85632547|Guernsey
+85633275|Luxembourg|Luxemburg|Lëtzebuerg (Land)
+85632461|Isle of Man|Mannin
+85632721|Cabo Verde
+85632553|Mali
+85633241|Ireland|Éire
+85633755|Србија
+85633229|Hrvatska
+85633779|Slovenija
+85632395|Беларусь|Белоруссия
+85632403|台灣

--- a/src/data/aliases/country-endonyms.psv
+++ b/src/data/aliases/country-endonyms.psv
@@ -1,202 +1,232 @@
+85632727|Netherlands
+85632733|Somalia
+1|Null Island
+1108955785|Socialist Federal Republic of Yugoslavia
+1108955787|Socialist Federal Republic of Yugoslavia
+1108955789|Kingdom of Yugoslavia
+1126113567|Socialist Federal Republic of Yugoslavia
+1108955783|Federal Republic of Yugoslavia
+421185849|Kazakhstan
+85632423|Guadeloupe
+85632523|Mayotte
+85632531|Martinique
+421202109|San Marino
+421188081|Sudan
+85632233|French Guiana
+85632351|Reunion
+421180189|Somalia
+421166797|Georgia
+85632495|Indian Ocean Territories
+85632371|Saint Pierre and Miquelon
 85632509|Philippines|República de Filipinas
-85633051|Schweiz|Schwyz|Suisse|Svizzera
-85633293|México
-85633745|România
+85633051|Schweiz|Schwyz|Suisse|Svizzera|Switzerland
+85633293|Mexico|México
+85633745|Romania|România
 85632343|Andorra
 85633143|Finland|Suomi
-85632757|Guiné-Bissau
-85633105|Česko
+85632757|Guinea-Bissau|Guiné-Bissau
+85633105|Czechia|Česko
 85632793|Australia
-85632573|الامارات
-85633279|Latvija
-85633341|Noreg|Norge
+85632573|United Arab Emirates|الامارات
+85633279|Latvia|Latvija
+85633341|Noreg|Norge|Norway
 85632755|Fiji|Viti
-85632191|العراق
-85632627|ليبيا
+85632191|Iraq|العراق
+85632627|Libya|ليبيا
 85633763|San Marino
 85632295|Aruba
-85632679|موريتانيا‎
-85633739|فلسطين
-85632513|Тоҷикистон
-85632465|नेपाल
+85632679|Mauritania|موريتانيا‎
+85633739|Palestine|فلسطين
+85632293|Thailand
+85632513|Tajikistan|Тоҷикистон
+85632465|Nepal|नेपाल
 85632431|Federated States of Micronesia
 85632749|Brunei
 85633285|Monaco
 102312305|Organización de las Naciones Unidas|United Nations|Организация Объединённых Наций|الأمم المتحدة
 85633345|Aotearoa|New Zealand
 85632623|Bolivia|Puliwya|Wuliwya
-85632365|Senegaal|Sénégal
+85632365|Senegaal|Senegal|Sénégal
 85633331|Malta
-85633249|Ísland
-85632433|Ayiti|Haïti
+85633249|Iceland|Ísland
+85632433|Ayiti|Haiti|Haïti
 85632235|Botswana
 85632455|Tonga
-85632241|ປະເທດລາວ
-85632405|Shqipëria
+85632241|Laos|ປະເທດລາວ
+85632405|Albania|Shqipëria
 85632661|Seychelles
-85632703|Tunisie|تونس
+85632703|Tunisia|Tunisie|تونس
 85632591|Solomon Islands
-85632765|São Tomé e Príncipe
-85632179|Panamá
+85632765|Sao Tome and Principe|São Tomé e Príncipe
+85632179|Panama|Panamá
 85632215|Jamaica
 85632339|The Bahamas
-85632671|Türkmenistan
-85632207|عمان
+85632671|Turkmenistan|Türkmenistan
+85632207|Oman|عمان
 85632593|Jersey
-85632609|Bosna i Hercegovina|Босна и Херцеговина
-85632253|السعودية
+85632609|Bosna i Hercegovina|Bosnia and Herzegovina|Босна и Херцеговина
+85632253|Saudi Arabia|السعودية
 85632529|Antigua and Barbuda
 85632303|Rwanda
 85632483|Hong Kong S.A.R.|香港
-85632229|افغانستان
-85633253|Italia
-85632499|اليمن
+85632229|Afghanistan|افغانستان
+85633253|Italia|Italy
+85632499|Yemen|اليمن
 85632383|Malawi|Malaŵi
-85632401|الكويت
-85632583|Timor-Leste|Timór Lorosa'e
-85632305|ދިވެހިރާއްޖެ
-85633121|Danmark
-85632379|Soomaaliya|الصومال‎
-85632393|Türkiye
-85633789|Sverige
+85632401|Kuwait|الكويت
+85632583|East Timor|Timor-Leste|Timór Lorosa'e
+85632305|Maldives|ދިވެހިރާއްޖެ
+85633121|Danmark|Denmark
+85632379|Somalia|Soomaaliya|الصومال‎
+85632393|Turkey|Türkiye
+85633789|Sverige|Sweden
 85632245|Cameroon|Cameroun
-85633111|Deutschland
+85633111|Deutschland|Germany
 85632511|Uruguay
-85632521|Perú|Piruw
+85632521|Peru|Perú|Piruw
 85632271|Trinidad and Tobago
 85633267|Liachtaschta|Liechtenstein
 85632347|Papua New Guinea|Papua Niugini
 85632185|Sint Maarten|Sint Maarten (land)
-85632313|இலங்கை|ශ්‍රී ලංකාව
+85632313|Sri Lanka|இலங்கை|ශ්‍රී ලංකාව
 85632545|El Salvador
-85632997|Belgien|Belgique|België
-85633237|Magyarország
-85632761|Киргизия|Кыргызстан
-85632167|البحرين
+85632997|Belgien|Belgique|Belgium|België
+85633237|Hungary|Magyarország
+85632761|Kyrgyzstan|Киргизия|Кыргызстан
+85632167|Bahrain|البحرين
 85632249|Liberia
 85632285|Burundi|Uburundi
-85632359|ព្រះរាជាណាចក្រកម្ពុជា
-85632325|Tchad|تشاد
-85632259|Comores|جزر القمر
+85632359|Cambodia|ព្រះរាជាណាចក្រកម្ពុជា
+85632325|Chad|Tchad|تشاد
+85632259|Comores|Comoros|جزر القمر
 85632551|Saint Kitts and Nevis
 85632647|Togo
-85632643|République démocratique du Congo
+85632643|Democratic Republic of Congo|République démocratique du Congo
 85632173|Lesotho
 85632227|Tanzania
-85632391|Ködörösêse tî Bêafrîka|République centrafricaine
-85632713|República Dominicana
+85632391|Central African Republic|Ködörösêse tî Bêafrîka|République centrafricaine
+85632713|Dominican Republic|República Dominicana
 85632635|Umbuso weSwatini|eSwatini
+85632739|Malaysia
 85633813|South Africa
-85632451|Algérie|الجزائر
-85632541|République du Congo
-85632729|Moçambique
+85632451|Algeria|Algérie|الجزائر
+85632541|Congo|République du Congo
+85632729|Mozambique|Moçambique
 85632625|Uganda
 85632559|Zambia
 85632261|Ecuador|Ikwadur
 85632535|Namibia|Namibië
 85632243|Zimbabwe
 85632189|Ghana
-85633135|Eesti
+85633135|Eesti|Estonia
 85632203|Indonesia
 85632605|Singapore|Singapura|சிங்கப்பூர்|新加坡
 85632269|Niger
 85632781|Eritrea|إريتريا|ኤርትራ
 85632281|Angola
-85633723|Polska
+85633723|Poland|Polska
 85632603|The Gambia
-85632691|Guinée
+85632691|Guinea|Guinée
 85632735|Nigeria|Nàìjíríà
-85632287|Guinea Ecuatorial|Guinée équatoriale
+85632287|Equatorial Guinea|Guinea Ecuatorial|Guinée équatoriale
 85632331|Belau|Palau
-85632299|قطر
+85632299|Qatar|قطر
 85632355|Paraguay|Paraguái
-85632257|ኢትዮጵያ
+85632257|Ethiopia|ኢትዮጵያ
 85632599|Nicaragua
-85632645|Oʻzbekiston
-85633337|Nederland
-85632161|Macau|澳门
-85632441|Curaçao|Pais Kòrsou
+85632645|Oʻzbekiston|Uzbekistan
+85633337|Nederland|Netherlands
+85632161|Macau|Macau S.A.R.|澳门
+85632441|Curacao|Curaçao|Pais Kòrsou
 85632681|Samoa|Sāmoa
 85632263|Ripablik blong Vanuatu|Vanuatu
-85632439|Монгол улс
+85632439|Mongolia|Монгол улс
 85632675|Cuba
-85632763|Việt Nam
-85632181|မြန်မာနိုင်ငံ
+85632763|Vietnam|Việt Nam
+85632181|Myanmar|မြန်မာနိုင်ငံ
 85632467|Sierra Leone
 85632487|Costa Rica
-85632785|Österreich
-85633769|Slovensko
+85632785|Austria|Österreich
+85633769|Slovakia|Slovensko
 85632223|Madagascar|Madagasikara
 85632569|Saint Vincent and the Grenadines
 85632663|Majõl|Marshall Islands
-85633259|Kosova|Република Косово
-85632429|日本
+85633259|Kosova|Kosovo|Република Косово
+85632429|Japan|日本
 85632213|Burkina Faso
-85633269|Lietuva
+85633269|Lietuva|Lithuania
 85632319|Djibouti|جيبوتي
-85632475|বাংলাদেশ
+85632475|Bangladesh|বাংলাদেশ
 85633041|Canada
 85633793|United States
-85633171|Ελλάδα
-85633001|България
-85632667|Црна Гора
+85633171|Greece|Ελλάδα
+85633001|Bulgaria|България
+85632667|Montenegro|Црна Гора
 85633159|United Kingdom
 85632397|Guyana
-85632639|조선민주주의인민공화국
-85632693|Maroc|المغرب
-85632361|ایران
-85632425|الأردن
-85632773|Հայաստան
+85632639|North Korea|조선민주주의인민공화국
+85632693|Maroc|Morocco|المغرب
+85633057|Chile
+85632361|Iran|ایران
+85632425|Jordan|الأردن
+85632773|Armenia|Հայաստան
 85632751|Sudan|السودان
-85632533|لبنان
-85632171|འབྲུག་ཡུལ་
-85632307|Казахстан|Қазақстан
+85632533|Lebanon|لبنان
+85632171|Bhutan|འབྲུག་ཡུལ་
+85632307|Kazakhstan|Казахстан|Қазақстан
 85632323|Honduras
 85632657|South Sudan
 85632407|Gabon
-85633009|Brasil
+85633009|Brasil|Brazil
 85633147|France
-85632685|Россия
-85632231|한국
-85632717|Azərbaycan
-85633287|Republica Moldova
-85633163|Sakartvelo
+85632685|Russia|Россия
+85632231|South Korea|한국
+85632717|Azerbaijan|Azərbaycan
+85633287|Moldova|Republica Moldova
+85633163|Georgia|Sakartvelo
 85632571|Belize
 85632329|Kenya
-85632413|Syrie|سوريا
-85632247|Bénin
-85633805|Украина|Україна
+85632413|Syria|Syrie|سوريا
+85632247|Benin|Bénin
+85633805|Ukraine|Украина|Україна
 85632659|Pakistan|پاکستان
-85632581|مصر
-85632315|ישראל|إسرائيل
-85633217|Kalaallit Nunaat
+85632581|Egypt|مصر
+85632315|Israel|ישראל|إسرائيل
+85633217|Greenland|Kalaallit Nunaat
 85632505|Argentina
 85632385|Guatemala
 85633735|Portugal
-85633129|España
+85633129|España|Spain
 85632469|India|भारत
 85632317|Venezuela
 85632519|Colombia
-85632373|Македонија
-85632449|Côte d'Ivoire
-85632437|Kıbrıs Cumhuriyeti|Κύπρος
+85632373|North Macedonia|Македонија
+85632695|China
+85632449|Côte d'Ivoire|Ivory Coast
+85632437|Cyprus|Kıbrıs Cumhuriyeti|Κύπρος
 85632747|Naoero|Nauru
 85632491|Barbados
 85632443|Suriname
 85632503|Dominica
 85632357|Maurice|Mauritius
+1729945891|Northern Cyprus
+1729989201|Siachen Glacier
+1729945893|Spratly Islands
 85632335|Grenada
 85632369|St. Lucia
 85632607|Tuvalu
 85632709|Kiribati|Ribaberiki Kiribati
 85632547|Guernsey
 85633275|Luxembourg|Luxemburg|Lëtzebuerg (Land)
+85632217|Western Sahara
+85632715|Antarctica
 85632461|Isle of Man|Mannin
-85632721|Cabo Verde
+85632721|Cabo Verde|Cape Verde
 85632553|Mali
+85632187|Vatican City
 85633241|Ireland|Éire
-85633755|Србија
-85633229|Hrvatska
-85633779|Slovenija
-85632395|Беларусь|Белоруссия
-85632403|台灣
+85633755|Serbia|Србија
+85633229|Croatia|Hrvatska
+85633779|Slovenia|Slovenija
+85632395|Belarus|Беларусь|Белоруссия
+85632403|Taiwan|台灣

--- a/src/data/aliases/country-language-map.json
+++ b/src/data/aliases/country-language-map.json
@@ -1,0 +1,2602 @@
+{
+  "85632509": {
+    "id": 85632509,
+    "placetype": "country",
+    "name": "Philippines",
+    "spoken": [
+      "eng",
+      "fil",
+      "ceb",
+      "ilo",
+      "hil",
+      "war",
+      "pag",
+      "mdh",
+      "tsg"
+    ],
+    "official": [
+      "eng",
+      "fil"
+    ]
+  },
+  "85633051": {
+    "id": 85633051,
+    "placetype": "country",
+    "name": "Switzerland",
+    "spoken": [
+      "deu",
+      "fra",
+      "gsw",
+      "ita",
+      "roh"
+    ],
+    "official": [
+      "deu",
+      "fra",
+      "gsw",
+      "ita"
+    ]
+  },
+  "85633293": {
+    "id": 85633293,
+    "placetype": "country",
+    "name": "Mexico",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85633745": {
+    "id": 85633745,
+    "placetype": "country",
+    "name": "Romania",
+    "spoken": [
+      "ron"
+    ],
+    "official": [
+      "ron"
+    ]
+  },
+  "85632343": {
+    "id": 85632343,
+    "placetype": "country",
+    "name": "Andorra",
+    "spoken": [
+      "cat"
+    ],
+    "official": [
+      "cat"
+    ]
+  },
+  "85633143": {
+    "id": 85633143,
+    "placetype": "country",
+    "name": "Finland",
+    "spoken": [
+      "fin",
+      "swe"
+    ],
+    "official": [
+      "fin",
+      "swe"
+    ]
+  },
+  "85632757": {
+    "id": 85632757,
+    "placetype": "country",
+    "name": "Guinea Bissau",
+    "spoken": [
+      "por"
+    ],
+    "official": [
+      "por"
+    ]
+  },
+  "85633105": {
+    "id": 85633105,
+    "placetype": "country",
+    "name": "Czech Republic",
+    "spoken": [
+      "ces"
+    ],
+    "official": [
+      "ces"
+    ]
+  },
+  "85632793": {
+    "id": 85632793,
+    "placetype": "country",
+    "name": "Australia",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632573": {
+    "id": 85632573,
+    "placetype": "country",
+    "name": "United Arab Emirates",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85633279": {
+    "id": 85633279,
+    "placetype": "country",
+    "name": "Latvia",
+    "spoken": [
+      "lav"
+    ],
+    "official": [
+      "lav"
+    ]
+  },
+  "85633341": {
+    "id": 85633341,
+    "placetype": "country",
+    "name": "Norway",
+    "spoken": [
+      "nor",
+      "nob",
+      "nno",
+      "sme"
+    ],
+    "official": [
+      "nor",
+      "nob",
+      "nno"
+    ]
+  },
+  "85632755": {
+    "id": 85632755,
+    "placetype": "country",
+    "name": "Fiji",
+    "spoken": [
+      "eng",
+      "hif",
+      "fij"
+    ],
+    "official": [
+      "eng",
+      "hif",
+      "fij"
+    ]
+  },
+  "85632191": {
+    "id": 85632191,
+    "placetype": "country",
+    "name": "Iraq",
+    "spoken": [
+      "ara",
+      "ckb"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85632627": {
+    "id": 85632627,
+    "placetype": "country",
+    "name": "Libya",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85633763": {
+    "id": 85633763,
+    "placetype": "country",
+    "name": "San Marino",
+    "spoken": [
+      "ita"
+    ],
+    "official": [
+      "ita"
+    ]
+  },
+  "85632295": {
+    "id": 85632295,
+    "placetype": "country",
+    "name": "Aruba",
+    "spoken": [
+      "nld",
+      "pap",
+      "eng",
+      "spa"
+    ],
+    "official": [
+      "nld",
+      "pap"
+    ]
+  },
+  "85632679": {
+    "id": 85632679,
+    "placetype": "country",
+    "name": "Mauritania",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85633739": {
+    "id": 85633739,
+    "placetype": "country",
+    "name": "Palestine",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85632293": {
+    "id": 85632293,
+    "placetype": "country",
+    "name": "Thailand",
+    "spoken": [],
+    "official": []
+  },
+  "85632513": {
+    "id": 85632513,
+    "placetype": "country",
+    "name": "Tajikistan",
+    "spoken": [
+      "tgk"
+    ],
+    "official": [
+      "tgk"
+    ]
+  },
+  "85632465": {
+    "id": 85632465,
+    "placetype": "country",
+    "name": "Nepal",
+    "spoken": [
+      "nep"
+    ],
+    "official": [
+      "nep"
+    ]
+  },
+  "85632431": {
+    "id": 85632431,
+    "placetype": "country",
+    "name": "Federated States of Micronesia",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632749": {
+    "id": 85632749,
+    "placetype": "country",
+    "name": "Brunei",
+    "spoken": [
+      "msa"
+    ],
+    "official": [
+      "msa"
+    ]
+  },
+  "85633285": {
+    "id": 85633285,
+    "placetype": "country",
+    "name": "Monaco",
+    "spoken": [
+      "fra"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "102312305": {
+    "id": 102312305,
+    "placetype": "country",
+    "name": "United Nations",
+    "spoken": [
+      "ara",
+      "chi",
+      "eng",
+      "fre",
+      "rus",
+      "spa",
+      "mul"
+    ],
+    "official": [
+      "ara",
+      "chi",
+      "eng",
+      "fre",
+      "rus",
+      "spa"
+    ]
+  },
+  "85633345": {
+    "id": 85633345,
+    "placetype": "country",
+    "name": "New Zealand",
+    "spoken": [
+      "eng",
+      "mri"
+    ],
+    "official": [
+      "eng",
+      "mri"
+    ]
+  },
+  "85632623": {
+    "id": 85632623,
+    "placetype": "country",
+    "name": "Bolivia",
+    "spoken": [
+      "spa",
+      "que",
+      "aym"
+    ],
+    "official": [
+      "spa",
+      "que",
+      "aym"
+    ]
+  },
+  "85632365": {
+    "id": 85632365,
+    "placetype": "country",
+    "name": "Senegal",
+    "spoken": [
+      "wol",
+      "fra"
+    ],
+    "official": [
+      "wol",
+      "fra"
+    ]
+  },
+  "85633331": {
+    "id": 85633331,
+    "placetype": "country",
+    "name": "Malta",
+    "spoken": [
+      "mlt",
+      "eng"
+    ],
+    "official": [
+      "mlt",
+      "eng"
+    ]
+  },
+  "85633249": {
+    "id": 85633249,
+    "placetype": "country",
+    "name": "Iceland",
+    "spoken": [
+      "isl"
+    ],
+    "official": [
+      "isl"
+    ]
+  },
+  "85632433": {
+    "id": 85632433,
+    "placetype": "country",
+    "name": "Haiti",
+    "spoken": [
+      "hat",
+      "fra"
+    ],
+    "official": [
+      "hat",
+      "fra"
+    ]
+  },
+  "85632235": {
+    "id": 85632235,
+    "placetype": "country",
+    "name": "Botswana",
+    "spoken": [
+      "eng",
+      "tsn"
+    ],
+    "official": [
+      "eng",
+      "tsn"
+    ]
+  },
+  "85632455": {
+    "id": 85632455,
+    "placetype": "country",
+    "name": "Tonga",
+    "spoken": [
+      "ton",
+      "eng"
+    ],
+    "official": [
+      "ton",
+      "eng"
+    ]
+  },
+  "85632241": {
+    "id": 85632241,
+    "placetype": "country",
+    "name": "Laos",
+    "spoken": [
+      "lao"
+    ],
+    "official": [
+      "lao"
+    ]
+  },
+  "85632405": {
+    "id": 85632405,
+    "placetype": "country",
+    "name": "Albania",
+    "spoken": [
+      "sqi"
+    ],
+    "official": [
+      "sqi"
+    ]
+  },
+  "85632661": {
+    "id": 85632661,
+    "placetype": "country",
+    "name": "Seychelles",
+    "spoken": [
+      "fra",
+      "eng"
+    ],
+    "official": [
+      "fra",
+      "eng"
+    ]
+  },
+  "85632703": {
+    "id": 85632703,
+    "placetype": "country",
+    "name": "Tunisia",
+    "spoken": [
+      "ara",
+      "fra"
+    ],
+    "official": [
+      "ara",
+      "fra"
+    ]
+  },
+  "85632591": {
+    "id": 85632591,
+    "placetype": "country",
+    "name": "Solomon Islands",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632765": {
+    "id": 85632765,
+    "placetype": "country",
+    "name": "Sao Tome and Principe",
+    "spoken": [
+      "por"
+    ],
+    "official": [
+      "por"
+    ]
+  },
+  "85632179": {
+    "id": 85632179,
+    "placetype": "country",
+    "name": "Panama",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632215": {
+    "id": 85632215,
+    "placetype": "country",
+    "name": "Jamaica",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632339": {
+    "id": 85632339,
+    "placetype": "country",
+    "name": "The Bahamas",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632671": {
+    "id": 85632671,
+    "placetype": "country",
+    "name": "Turkmenistan",
+    "spoken": [
+      "tuk"
+    ],
+    "official": [
+      "tuk"
+    ]
+  },
+  "85632207": {
+    "id": 85632207,
+    "placetype": "country",
+    "name": "Oman",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85632593": {
+    "id": 85632593,
+    "placetype": "country",
+    "name": "Jersey",
+    "spoken": [
+      "eng",
+      "fre"
+    ],
+    "official": [
+      "eng",
+      "fre"
+    ]
+  },
+  "85632609": {
+    "id": 85632609,
+    "placetype": "country",
+    "name": "Bosnia and Herzegovina",
+    "spoken": [
+      "bos",
+      "srp",
+      "hrv"
+    ],
+    "official": [
+      "bos",
+      "srp",
+      "hrv"
+    ]
+  },
+  "85632253": {
+    "id": 85632253,
+    "placetype": "country",
+    "name": "Saudi Arabia",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85632529": {
+    "id": 85632529,
+    "placetype": "country",
+    "name": "Antigua and Barbuda",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632303": {
+    "id": 85632303,
+    "placetype": "country",
+    "name": "Rwanda",
+    "spoken": [
+      "kin",
+      "fra",
+      "eng"
+    ],
+    "official": [
+      "kin",
+      "fra",
+      "eng"
+    ]
+  },
+  "85632483": {
+    "id": 85632483,
+    "placetype": "country",
+    "name": "Hong Kong S.A.R.",
+    "spoken": [
+      "zho",
+      "eng"
+    ],
+    "official": [
+      "zho",
+      "eng"
+    ]
+  },
+  "85632229": {
+    "id": 85632229,
+    "placetype": "country",
+    "name": "Afghanistan",
+    "spoken": [
+      "fas",
+      "pus",
+      "uzb",
+      "tuk",
+      "bal"
+    ],
+    "official": [
+      "fas",
+      "pus"
+    ]
+  },
+  "85633253": {
+    "id": 85633253,
+    "placetype": "country",
+    "name": "Italy",
+    "spoken": [
+      "ita",
+      "fra"
+    ],
+    "official": [
+      "ita"
+    ]
+  },
+  "85632499": {
+    "id": 85632499,
+    "placetype": "country",
+    "name": "Yemen",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85632383": {
+    "id": 85632383,
+    "placetype": "country",
+    "name": "Malawi",
+    "spoken": [
+      "nya",
+      "eng"
+    ],
+    "official": [
+      "nya",
+      "eng"
+    ]
+  },
+  "85632401": {
+    "id": 85632401,
+    "placetype": "country",
+    "name": "Kuwait",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85632583": {
+    "id": 85632583,
+    "placetype": "country",
+    "name": "East Timor",
+    "spoken": [
+      "tet",
+      "por"
+    ],
+    "official": [
+      "tet",
+      "por"
+    ]
+  },
+  "85632305": {
+    "id": 85632305,
+    "placetype": "country",
+    "name": "Maldives",
+    "spoken": [
+      "div"
+    ],
+    "official": [
+      "div"
+    ]
+  },
+  "85633121": {
+    "id": 85633121,
+    "placetype": "country",
+    "name": "Denmark",
+    "spoken": [
+      "dan",
+      "deu",
+      "kal"
+    ],
+    "official": [
+      "dan"
+    ]
+  },
+  "85632379": {
+    "id": 85632379,
+    "placetype": "country",
+    "name": "Somalia",
+    "spoken": [
+      "som",
+      "ara"
+    ],
+    "official": [
+      "som",
+      "ara"
+    ]
+  },
+  "85632393": {
+    "id": 85632393,
+    "placetype": "country",
+    "name": "Turkey",
+    "spoken": [
+      "tur"
+    ],
+    "official": [
+      "tur"
+    ]
+  },
+  "85633789": {
+    "id": 85633789,
+    "placetype": "country",
+    "name": "Sweden",
+    "spoken": [
+      "swe",
+      "fin"
+    ],
+    "official": [
+      "swe"
+    ]
+  },
+  "85632245": {
+    "id": 85632245,
+    "placetype": "country",
+    "name": "Cameroon",
+    "spoken": [
+      "fra",
+      "eng"
+    ],
+    "official": [
+      "fra",
+      "eng"
+    ]
+  },
+  "85633111": {
+    "id": 85633111,
+    "placetype": "country",
+    "name": "Germany",
+    "spoken": [
+      "deu"
+    ],
+    "official": [
+      "deu"
+    ]
+  },
+  "85632511": {
+    "id": 85632511,
+    "placetype": "country",
+    "name": "Uruguay",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632521": {
+    "id": 85632521,
+    "placetype": "country",
+    "name": "Peru",
+    "spoken": [
+      "spa",
+      "que"
+    ],
+    "official": [
+      "spa",
+      "que"
+    ]
+  },
+  "85632271": {
+    "id": 85632271,
+    "placetype": "country",
+    "name": "Trinidad and Tobago",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85633267": {
+    "id": 85633267,
+    "placetype": "country",
+    "name": "Liechtenstein",
+    "spoken": [
+      "deu",
+      "gsw"
+    ],
+    "official": [
+      "deu",
+      "gsw"
+    ]
+  },
+  "85632347": {
+    "id": 85632347,
+    "placetype": "country",
+    "name": "Papua New Guinea",
+    "spoken": [
+      "tpi",
+      "eng",
+      "hmo"
+    ],
+    "official": [
+      "tpi",
+      "eng",
+      "hmo"
+    ]
+  },
+  "85632185": {
+    "id": 85632185,
+    "placetype": "country",
+    "name": "Sint Maarten",
+    "spoken": [
+      "eng",
+      "nld"
+    ],
+    "official": [
+      "eng",
+      "nld"
+    ]
+  },
+  "85632313": {
+    "id": 85632313,
+    "placetype": "country",
+    "name": "Sri Lanka",
+    "spoken": [
+      "sin",
+      "tam"
+    ],
+    "official": [
+      "sin",
+      "tam"
+    ]
+  },
+  "85632545": {
+    "id": 85632545,
+    "placetype": "country",
+    "name": "El Salvador",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632997": {
+    "id": 85632997,
+    "placetype": "country",
+    "name": "Belgium",
+    "spoken": [
+      "nld",
+      "fra",
+      "deu"
+    ],
+    "official": [
+      "nld",
+      "fra",
+      "deu"
+    ]
+  },
+  "85633237": {
+    "id": 85633237,
+    "placetype": "country",
+    "name": "Hungary",
+    "spoken": [
+      "hun"
+    ],
+    "official": [
+      "hun"
+    ]
+  },
+  "85632761": {
+    "id": 85632761,
+    "placetype": "country",
+    "name": "Kyrgyzstan",
+    "spoken": [
+      "kir",
+      "rus"
+    ],
+    "official": [
+      "kir",
+      "rus"
+    ]
+  },
+  "85632167": {
+    "id": 85632167,
+    "placetype": "country",
+    "name": "Bahrain",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85632249": {
+    "id": 85632249,
+    "placetype": "country",
+    "name": "Liberia",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632285": {
+    "id": 85632285,
+    "placetype": "country",
+    "name": "Burundi",
+    "spoken": [
+      "run",
+      "fra"
+    ],
+    "official": [
+      "run",
+      "fra"
+    ]
+  },
+  "85632359": {
+    "id": 85632359,
+    "placetype": "country",
+    "name": "Cambodia",
+    "spoken": [
+      "khm"
+    ],
+    "official": [
+      "khm"
+    ]
+  },
+  "85632325": {
+    "id": 85632325,
+    "placetype": "country",
+    "name": "Chad",
+    "spoken": [
+      "fra",
+      "ara"
+    ],
+    "official": [
+      "fra",
+      "ara"
+    ]
+  },
+  "85632259": {
+    "id": 85632259,
+    "placetype": "country",
+    "name": "Comoros",
+    "spoken": [
+      "ara",
+      "fra",
+      "zdj"
+    ],
+    "official": [
+      "ara",
+      "fra",
+      "zdj"
+    ]
+  },
+  "85632551": {
+    "id": 85632551,
+    "placetype": "country",
+    "name": "Saint Kitts and Nevis",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632647": {
+    "id": 85632647,
+    "placetype": "country",
+    "name": "Togo",
+    "spoken": [
+      "fra"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "85632643": {
+    "id": 85632643,
+    "placetype": "country",
+    "name": "Democratic Republic of the Congo",
+    "spoken": [
+      "swa",
+      "lua",
+      "fra",
+      "lin",
+      "kon"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "85632173": {
+    "id": 85632173,
+    "placetype": "country",
+    "name": "Lesotho",
+    "spoken": [
+      "sot",
+      "eng"
+    ],
+    "official": [
+      "sot",
+      "eng"
+    ]
+  },
+  "85632227": {
+    "id": 85632227,
+    "placetype": "country",
+    "name": "Tanzania",
+    "spoken": [
+      "swa",
+      "eng"
+    ],
+    "official": [
+      "swa",
+      "eng"
+    ]
+  },
+  "85632391": {
+    "id": 85632391,
+    "placetype": "country",
+    "name": "Central African Republic",
+    "spoken": [
+      "fra",
+      "sag"
+    ],
+    "official": [
+      "fra",
+      "sag"
+    ]
+  },
+  "85632713": {
+    "id": 85632713,
+    "placetype": "country",
+    "name": "Dominican Republic",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632635": {
+    "id": 85632635,
+    "placetype": "country",
+    "name": "eSwatini",
+    "spoken": [
+      "eng",
+      "ssw"
+    ],
+    "official": [
+      "eng",
+      "ssw"
+    ]
+  },
+  "85632739": {
+    "id": 85632739,
+    "placetype": "country",
+    "name": "Malaysia",
+    "spoken": [],
+    "official": []
+  },
+  "85633813": {
+    "id": 85633813,
+    "placetype": "country",
+    "name": "South Africa",
+    "spoken": [
+      "eng",
+      "zul",
+      "xho",
+      "afr",
+      "nso",
+      "tsn",
+      "sot",
+      "tso",
+      "ssw",
+      "ven",
+      "nbl"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632451": {
+    "id": 85632451,
+    "placetype": "country",
+    "name": "Algeria",
+    "spoken": [
+      "ara",
+      "fra"
+    ],
+    "official": [
+      "ara",
+      "fra"
+    ]
+  },
+  "85632541": {
+    "id": 85632541,
+    "placetype": "country",
+    "name": "Republic of Congo",
+    "spoken": [
+      "fra"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "85632729": {
+    "id": 85632729,
+    "placetype": "country",
+    "name": "Mozambique",
+    "spoken": [
+      "por"
+    ],
+    "official": [
+      "por"
+    ]
+  },
+  "85632625": {
+    "id": 85632625,
+    "placetype": "country",
+    "name": "Uganda",
+    "spoken": [
+      "swa",
+      "eng"
+    ],
+    "official": [
+      "swa",
+      "eng"
+    ]
+  },
+  "85632559": {
+    "id": 85632559,
+    "placetype": "country",
+    "name": "Zambia",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632261": {
+    "id": 85632261,
+    "placetype": "country",
+    "name": "Ecuador",
+    "spoken": [
+      "spa",
+      "que"
+    ],
+    "official": [
+      "spa",
+      "que"
+    ]
+  },
+  "85632535": {
+    "id": 85632535,
+    "placetype": "country",
+    "name": "Namibia",
+    "spoken": [
+      "afr",
+      "eng"
+    ],
+    "official": [
+      "afr",
+      "eng"
+    ]
+  },
+  "85632243": {
+    "id": 85632243,
+    "placetype": "country",
+    "name": "Zimbabwe",
+    "spoken": [
+      "eng",
+      "sna",
+      "nde"
+    ],
+    "official": [
+      "eng",
+      "sna",
+      "nde"
+    ]
+  },
+  "85632189": {
+    "id": 85632189,
+    "placetype": "country",
+    "name": "Ghana",
+    "spoken": [
+      "aka",
+      "eng",
+      "ewe",
+      "gaa"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85633135": {
+    "id": 85633135,
+    "placetype": "country",
+    "name": "Estonia",
+    "spoken": [
+      "est"
+    ],
+    "official": [
+      "est"
+    ]
+  },
+  "85632203": {
+    "id": 85632203,
+    "placetype": "country",
+    "name": "Indonesia",
+    "spoken": [
+      "ind",
+      "eng"
+    ],
+    "official": [
+      "ind"
+    ]
+  },
+  "85632605": {
+    "id": 85632605,
+    "placetype": "country",
+    "name": "Singapore",
+    "spoken": [
+      "eng",
+      "zho",
+      "msa",
+      "tam"
+    ],
+    "official": [
+      "eng",
+      "zho",
+      "msa",
+      "tam"
+    ]
+  },
+  "85632269": {
+    "id": 85632269,
+    "placetype": "country",
+    "name": "Niger",
+    "spoken": [
+      "fra"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "85632781": {
+    "id": 85632781,
+    "placetype": "country",
+    "name": "Eritrea",
+    "spoken": [
+      "tir",
+      "eng",
+      "ara"
+    ],
+    "official": [
+      "tir",
+      "eng",
+      "ara"
+    ]
+  },
+  "85632281": {
+    "id": 85632281,
+    "placetype": "country",
+    "name": "Angola",
+    "spoken": [
+      "por"
+    ],
+    "official": [
+      "por"
+    ]
+  },
+  "85633723": {
+    "id": 85633723,
+    "placetype": "country",
+    "name": "Poland",
+    "spoken": [
+      "pol",
+      "csb",
+      "deu",
+      "lit"
+    ],
+    "official": [
+      "pol"
+    ]
+  },
+  "85632603": {
+    "id": 85632603,
+    "placetype": "country",
+    "name": "Gambia",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632691": {
+    "id": 85632691,
+    "placetype": "country",
+    "name": "Guinea",
+    "spoken": [
+      "fra"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "85632735": {
+    "id": 85632735,
+    "placetype": "country",
+    "name": "Nigeria",
+    "spoken": [
+      "eng",
+      "yor"
+    ],
+    "official": [
+      "eng",
+      "yor"
+    ]
+  },
+  "85632287": {
+    "id": 85632287,
+    "placetype": "country",
+    "name": "Equatorial Guinea",
+    "spoken": [
+      "spa",
+      "fra"
+    ],
+    "official": [
+      "spa",
+      "fra"
+    ]
+  },
+  "85632331": {
+    "id": 85632331,
+    "placetype": "country",
+    "name": "Palau",
+    "spoken": [
+      "pau",
+      "eng"
+    ],
+    "official": [
+      "pau",
+      "eng"
+    ]
+  },
+  "85632299": {
+    "id": 85632299,
+    "placetype": "country",
+    "name": "Qatar",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85632355": {
+    "id": 85632355,
+    "placetype": "country",
+    "name": "Paraguay",
+    "spoken": [
+      "grn",
+      "spa"
+    ],
+    "official": [
+      "grn",
+      "spa"
+    ]
+  },
+  "85632257": {
+    "id": 85632257,
+    "placetype": "country",
+    "name": "Ethiopia",
+    "spoken": [
+      "amh"
+    ],
+    "official": [
+      "amh"
+    ]
+  },
+  "85632599": {
+    "id": 85632599,
+    "placetype": "country",
+    "name": "Nicaragua",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632645": {
+    "id": 85632645,
+    "placetype": "country",
+    "name": "Uzbekistan",
+    "spoken": [
+      "uzb"
+    ],
+    "official": [
+      "uzb"
+    ]
+  },
+  "85633337": {
+    "id": 85633337,
+    "placetype": "country",
+    "name": "Netherlands",
+    "spoken": [
+      "nld",
+      "fry"
+    ],
+    "official": [
+      "nld"
+    ]
+  },
+  "85632161": {
+    "id": 85632161,
+    "placetype": "country",
+    "name": "Macau S.A.R.",
+    "spoken": [
+      "zho",
+      "por"
+    ],
+    "official": [
+      "zho",
+      "por"
+    ]
+  },
+  "85632441": {
+    "id": 85632441,
+    "placetype": "country",
+    "name": "Curacao",
+    "spoken": [
+      "pap",
+      "nld"
+    ],
+    "official": [
+      "pap",
+      "nld"
+    ]
+  },
+  "85632681": {
+    "id": 85632681,
+    "placetype": "country",
+    "name": "Samoa",
+    "spoken": [
+      "smo",
+      "eng"
+    ],
+    "official": [
+      "smo",
+      "eng"
+    ]
+  },
+  "85632263": {
+    "id": 85632263,
+    "placetype": "country",
+    "name": "Vanuatu",
+    "spoken": [
+      "bis",
+      "eng",
+      "fra"
+    ],
+    "official": [
+      "bis",
+      "eng",
+      "fra"
+    ]
+  },
+  "85632439": {
+    "id": 85632439,
+    "placetype": "country",
+    "name": "Mongolia",
+    "spoken": [
+      "mon"
+    ],
+    "official": [
+      "mon"
+    ]
+  },
+  "85632675": {
+    "id": 85632675,
+    "placetype": "country",
+    "name": "Cuba",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632763": {
+    "id": 85632763,
+    "placetype": "country",
+    "name": "Vietnam",
+    "spoken": [
+      "vie"
+    ],
+    "official": [
+      "vie"
+    ]
+  },
+  "85632181": {
+    "id": 85632181,
+    "placetype": "country",
+    "name": "Myanmar",
+    "spoken": [
+      "mya"
+    ],
+    "official": [
+      "mya"
+    ]
+  },
+  "85632467": {
+    "id": 85632467,
+    "placetype": "country",
+    "name": "Sierra Leone",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632487": {
+    "id": 85632487,
+    "placetype": "country",
+    "name": "Costa Rica",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632785": {
+    "id": 85632785,
+    "placetype": "country",
+    "name": "Austria",
+    "spoken": [
+      "deu",
+      "hrv",
+      "slv",
+      "hun"
+    ],
+    "official": [
+      "deu"
+    ]
+  },
+  "85633769": {
+    "id": 85633769,
+    "placetype": "country",
+    "name": "Slovakia",
+    "spoken": [
+      "slk"
+    ],
+    "official": [
+      "slk"
+    ]
+  },
+  "85632223": {
+    "id": 85632223,
+    "placetype": "country",
+    "name": "Madagascar",
+    "spoken": [
+      "mlg",
+      "fra",
+      "eng"
+    ],
+    "official": [
+      "mlg",
+      "fra",
+      "eng"
+    ]
+  },
+  "85632569": {
+    "id": 85632569,
+    "placetype": "country",
+    "name": "Saint Vincent and the Grenadines",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632663": {
+    "id": 85632663,
+    "placetype": "country",
+    "name": "Marshall Islands",
+    "spoken": [
+      "eng",
+      "mah"
+    ],
+    "official": [
+      "eng",
+      "mah"
+    ]
+  },
+  "85633259": {
+    "id": 85633259,
+    "placetype": "country",
+    "name": "Kosovo",
+    "spoken": [
+      "sqi",
+      "srp",
+      "tur",
+      "bos",
+      "rom"
+    ],
+    "official": [
+      "sqi",
+      "srp"
+    ]
+  },
+  "85632429": {
+    "id": 85632429,
+    "placetype": "country",
+    "name": "Japan",
+    "spoken": [
+      "jpn"
+    ],
+    "official": [
+      "jpn"
+    ]
+  },
+  "85632213": {
+    "id": 85632213,
+    "placetype": "country",
+    "name": "Burkina Faso",
+    "spoken": [
+      "fra"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "85633269": {
+    "id": 85633269,
+    "placetype": "country",
+    "name": "Lithuania",
+    "spoken": [
+      "lit"
+    ],
+    "official": [
+      "lit"
+    ]
+  },
+  "85632319": {
+    "id": 85632319,
+    "placetype": "country",
+    "name": "Djibouti",
+    "spoken": [
+      "ara",
+      "fra"
+    ],
+    "official": [
+      "ara",
+      "fra"
+    ]
+  },
+  "85632475": {
+    "id": 85632475,
+    "placetype": "country",
+    "name": "Bangladesh",
+    "spoken": [
+      "ben"
+    ],
+    "official": [
+      "ben"
+    ]
+  },
+  "85633041": {
+    "id": 85633041,
+    "placetype": "country",
+    "name": "Canada",
+    "spoken": [
+      "eng",
+      "fra",
+      "iku",
+      "ikt"
+    ],
+    "official": [
+      "eng",
+      "fra"
+    ]
+  },
+  "85633793": {
+    "id": 85633793,
+    "placetype": "country",
+    "name": "United States",
+    "spoken": [
+      "eng",
+      "spa",
+      "haw"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85633171": {
+    "id": 85633171,
+    "placetype": "country",
+    "name": "Greece",
+    "spoken": [
+      "ell"
+    ],
+    "official": [
+      "ell"
+    ]
+  },
+  "85633001": {
+    "id": 85633001,
+    "placetype": "country",
+    "name": "Bulgaria",
+    "spoken": [
+      "bul"
+    ],
+    "official": [
+      "bul"
+    ]
+  },
+  "85632667": {
+    "id": 85632667,
+    "placetype": "country",
+    "name": "Montenegro",
+    "spoken": [
+      "srp"
+    ],
+    "official": [
+      "srp"
+    ]
+  },
+  "85633159": {
+    "id": 85633159,
+    "placetype": "country",
+    "name": "United Kingdom",
+    "spoken": [
+      "eng",
+      "cym",
+      "gla",
+      "gle"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632397": {
+    "id": 85632397,
+    "placetype": "country",
+    "name": "Guyana",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632639": {
+    "id": 85632639,
+    "placetype": "country",
+    "name": "North Korea",
+    "spoken": [
+      "kor"
+    ],
+    "official": [
+      "kor"
+    ]
+  },
+  "85632693": {
+    "id": 85632693,
+    "placetype": "country",
+    "name": "Morocco",
+    "spoken": [
+      "ara",
+      "fra",
+      "tzm"
+    ],
+    "official": [
+      "ara",
+      "fra",
+      "tzm"
+    ]
+  },
+  "85633057": {
+    "id": 85633057,
+    "placetype": "country",
+    "name": "Chile",
+    "spoken": [],
+    "official": []
+  },
+  "85632361": {
+    "id": 85632361,
+    "placetype": "country",
+    "name": "Iran",
+    "spoken": [
+      "fas"
+    ],
+    "official": [
+      "fas"
+    ]
+  },
+  "85632425": {
+    "id": 85632425,
+    "placetype": "country",
+    "name": "Jordan",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85632773": {
+    "id": 85632773,
+    "placetype": "country",
+    "name": "Armenia",
+    "spoken": [
+      "hye"
+    ],
+    "official": [
+      "hye"
+    ]
+  },
+  "85632751": {
+    "id": 85632751,
+    "placetype": "country",
+    "name": "Sudan",
+    "spoken": [
+      "ara",
+      "eng"
+    ],
+    "official": [
+      "ara",
+      "eng"
+    ]
+  },
+  "85632533": {
+    "id": 85632533,
+    "placetype": "country",
+    "name": "Lebanon",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85632171": {
+    "id": 85632171,
+    "placetype": "country",
+    "name": "Bhutan",
+    "spoken": [
+      "dzo"
+    ],
+    "official": [
+      "dzo"
+    ]
+  },
+  "85632307": {
+    "id": 85632307,
+    "placetype": "country",
+    "name": "Kazakhstan",
+    "spoken": [
+      "rus",
+      "kaz"
+    ],
+    "official": [
+      "rus",
+      "kaz"
+    ]
+  },
+  "85632323": {
+    "id": 85632323,
+    "placetype": "country",
+    "name": "Honduras",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632657": {
+    "id": 85632657,
+    "placetype": "country",
+    "name": "South Sudan",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632407": {
+    "id": 85632407,
+    "placetype": "country",
+    "name": "Gabon",
+    "spoken": [
+      "fra"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "85633009": {
+    "id": 85633009,
+    "placetype": "country",
+    "name": "Brazil",
+    "spoken": [
+      "por"
+    ],
+    "official": [
+      "por"
+    ]
+  },
+  "85633147": {
+    "id": 85633147,
+    "placetype": "country",
+    "name": "France",
+    "spoken": [
+      "fra"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "85632685": {
+    "id": 85632685,
+    "placetype": "country",
+    "name": "Russia",
+    "spoken": [
+      "rus",
+      "tat",
+      "bak",
+      "che",
+      "ava",
+      "udm",
+      "sah",
+      "myv",
+      "kbd",
+      "mdf",
+      "kum",
+      "lez",
+      "kom",
+      "inh",
+      "krc",
+      "tyv",
+      "aze",
+      "ady",
+      "lbe",
+      "koi"
+    ],
+    "official": [
+      "rus"
+    ]
+  },
+  "85632231": {
+    "id": 85632231,
+    "placetype": "country",
+    "name": "South Korea",
+    "spoken": [
+      "kor"
+    ],
+    "official": [
+      "kor"
+    ]
+  },
+  "85632717": {
+    "id": 85632717,
+    "placetype": "country",
+    "name": "Azerbaijan",
+    "spoken": [
+      "aze"
+    ],
+    "official": [
+      "aze"
+    ]
+  },
+  "85633287": {
+    "id": 85633287,
+    "placetype": "country",
+    "name": "Moldova",
+    "spoken": [
+      "ron"
+    ],
+    "official": [
+      "ron"
+    ]
+  },
+  "85633163": {
+    "id": 85633163,
+    "placetype": "country",
+    "name": "Georgia",
+    "spoken": [
+      "kat",
+      "abk",
+      "oss"
+    ],
+    "official": [
+      "kat"
+    ]
+  },
+  "85632571": {
+    "id": 85632571,
+    "placetype": "country",
+    "name": "Belize",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632329": {
+    "id": 85632329,
+    "placetype": "country",
+    "name": "Kenya",
+    "spoken": [
+      "eng",
+      "swa"
+    ],
+    "official": [
+      "eng",
+      "swa"
+    ]
+  },
+  "85632413": {
+    "id": 85632413,
+    "placetype": "country",
+    "name": "Syria",
+    "spoken": [
+      "ara",
+      "fra"
+    ],
+    "official": [
+      "ara",
+      "fra"
+    ]
+  },
+  "85632247": {
+    "id": 85632247,
+    "placetype": "country",
+    "name": "Benin",
+    "spoken": [
+      "fra"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "85633805": {
+    "id": 85633805,
+    "placetype": "country",
+    "name": "Ukraine",
+    "spoken": [
+      "ukr",
+      "rus"
+    ],
+    "official": [
+      "ukr",
+      "rus"
+    ]
+  },
+  "85632659": {
+    "id": 85632659,
+    "placetype": "country",
+    "name": "Pakistan",
+    "spoken": [
+      "urd",
+      "eng"
+    ],
+    "official": [
+      "urd",
+      "eng"
+    ]
+  },
+  "85632581": {
+    "id": 85632581,
+    "placetype": "country",
+    "name": "Egypt",
+    "spoken": [
+      "ara"
+    ],
+    "official": [
+      "ara"
+    ]
+  },
+  "85632315": {
+    "id": 85632315,
+    "placetype": "country",
+    "name": "Israel",
+    "spoken": [
+      "heb",
+      "ara",
+      "eng"
+    ],
+    "official": [
+      "heb",
+      "ara"
+    ]
+  },
+  "85633217": {
+    "id": 85633217,
+    "placetype": "country",
+    "name": "Greenland",
+    "spoken": [
+      "kal"
+    ],
+    "official": [
+      "kal"
+    ]
+  },
+  "85632505": {
+    "id": 85632505,
+    "placetype": "country",
+    "name": "Argentina",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632385": {
+    "id": 85632385,
+    "placetype": "country",
+    "name": "Guatemala",
+    "spoken": [
+      "spa",
+      "quc"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85633735": {
+    "id": 85633735,
+    "placetype": "country",
+    "name": "Portugal",
+    "spoken": [
+      "por"
+    ],
+    "official": [
+      "por"
+    ]
+  },
+  "85633129": {
+    "id": 85633129,
+    "placetype": "country",
+    "name": "Spain",
+    "spoken": [
+      "spa",
+      "cat",
+      "glg",
+      "eus",
+      "ast"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632469": {
+    "id": 85632469,
+    "placetype": "country",
+    "name": "India",
+    "spoken": [
+      "hin",
+      "eng",
+      "ben",
+      "tel",
+      "mar",
+      "tam",
+      "urd",
+      "guj",
+      "kan",
+      "mal",
+      "ori",
+      "pan",
+      "asm",
+      "mai",
+      "nep",
+      "sat",
+      "kas",
+      "kok",
+      "snd",
+      "kha",
+      "san"
+    ],
+    "official": [
+      "hin",
+      "eng"
+    ]
+  },
+  "85632317": {
+    "id": 85632317,
+    "placetype": "country",
+    "name": "Venezuela",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632519": {
+    "id": 85632519,
+    "placetype": "country",
+    "name": "Colombia",
+    "spoken": [
+      "spa"
+    ],
+    "official": [
+      "spa"
+    ]
+  },
+  "85632373": {
+    "id": 85632373,
+    "placetype": "country",
+    "name": "North Macedonia",
+    "spoken": [
+      "mkd",
+      "sqi"
+    ],
+    "official": [
+      "mkd"
+    ]
+  },
+  "85632695": {
+    "id": 85632695,
+    "placetype": "country",
+    "name": "China",
+    "spoken": [],
+    "official": []
+  },
+  "85632449": {
+    "id": 85632449,
+    "placetype": "country",
+    "name": "Ivory Coast",
+    "spoken": [
+      "fra"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "85632437": {
+    "id": 85632437,
+    "placetype": "country",
+    "name": "Cyprus",
+    "spoken": [
+      "ell",
+      "tur"
+    ],
+    "official": [
+      "ell",
+      "tur"
+    ]
+  },
+  "85632747": {
+    "id": 85632747,
+    "placetype": "country",
+    "name": "Nauru",
+    "spoken": [
+      "eng",
+      "nau"
+    ],
+    "official": [
+      "eng",
+      "nau"
+    ]
+  },
+  "85632491": {
+    "id": 85632491,
+    "placetype": "country",
+    "name": "Barbados",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632443": {
+    "id": 85632443,
+    "placetype": "country",
+    "name": "Suriname",
+    "spoken": [
+      "nld"
+    ],
+    "official": [
+      "nld"
+    ]
+  },
+  "85632503": {
+    "id": 85632503,
+    "placetype": "country",
+    "name": "Dominica",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632357": {
+    "id": 85632357,
+    "placetype": "country",
+    "name": "Mauritius",
+    "spoken": [
+      "eng",
+      "fra"
+    ],
+    "official": [
+      "eng",
+      "fra"
+    ]
+  },
+  "1729945891": {
+    "id": 1729945891,
+    "placetype": "country",
+    "name": "Northern Cyprus",
+    "spoken": [],
+    "official": []
+  },
+  "1729989201": {
+    "id": 1729989201,
+    "placetype": "country",
+    "name": "Siachen Glacier",
+    "spoken": [],
+    "official": []
+  },
+  "1729945893": {
+    "id": 1729945893,
+    "placetype": "country",
+    "name": "Spratly Islands",
+    "spoken": [],
+    "official": []
+  },
+  "85632335": {
+    "id": 85632335,
+    "placetype": "country",
+    "name": "Grenada",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632369": {
+    "id": 85632369,
+    "placetype": "country",
+    "name": "Saint Lucia",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85632607": {
+    "id": 85632607,
+    "placetype": "country",
+    "name": "Tuvalu",
+    "spoken": [
+      "tvl",
+      "eng"
+    ],
+    "official": [
+      "tvl",
+      "eng"
+    ]
+  },
+  "85632709": {
+    "id": 85632709,
+    "placetype": "country",
+    "name": "Kiribati",
+    "spoken": [
+      "eng",
+      "gil"
+    ],
+    "official": [
+      "eng",
+      "gil"
+    ]
+  },
+  "85632547": {
+    "id": 85632547,
+    "placetype": "country",
+    "name": "Guernsey",
+    "spoken": [
+      "eng"
+    ],
+    "official": [
+      "eng"
+    ]
+  },
+  "85633275": {
+    "id": 85633275,
+    "placetype": "country",
+    "name": "Luxembourg",
+    "spoken": [
+      "fra",
+      "ltz",
+      "deu"
+    ],
+    "official": [
+      "fra",
+      "ltz",
+      "deu"
+    ]
+  },
+  "85632217": {
+    "id": 85632217,
+    "placetype": "country",
+    "name": "Western Sahara",
+    "spoken": [],
+    "official": []
+  },
+  "85632715": {
+    "id": 85632715,
+    "placetype": "country",
+    "name": "Antarctica",
+    "spoken": [],
+    "official": []
+  },
+  "85632461": {
+    "id": 85632461,
+    "placetype": "country",
+    "name": "Isle of Man",
+    "spoken": [
+      "eng",
+      "glv"
+    ],
+    "official": [
+      "eng",
+      "glv"
+    ]
+  },
+  "85632721": {
+    "id": 85632721,
+    "placetype": "country",
+    "name": "Cape Verde",
+    "spoken": [
+      "por"
+    ],
+    "official": [
+      "por"
+    ]
+  },
+  "85632553": {
+    "id": 85632553,
+    "placetype": "country",
+    "name": "Mali",
+    "spoken": [
+      "fra"
+    ],
+    "official": [
+      "fra"
+    ]
+  },
+  "85632187": {
+    "id": 85632187,
+    "placetype": "country",
+    "name": "Vatican",
+    "spoken": [
+      "ita"
+    ],
+    "official": []
+  },
+  "85633241": {
+    "id": 85633241,
+    "placetype": "country",
+    "name": "Ireland",
+    "spoken": [
+      "eng",
+      "gle"
+    ],
+    "official": [
+      "eng",
+      "gle"
+    ]
+  },
+  "85633755": {
+    "id": 85633755,
+    "placetype": "country",
+    "name": "Serbia",
+    "spoken": [
+      "srp",
+      "hun",
+      "ron",
+      "hrv",
+      "slk",
+      "ukr"
+    ],
+    "official": [
+      "srp"
+    ]
+  },
+  "85633229": {
+    "id": 85633229,
+    "placetype": "country",
+    "name": "Croatia",
+    "spoken": [
+      "hrv",
+      "ita"
+    ],
+    "official": [
+      "hrv"
+    ]
+  },
+  "85633779": {
+    "id": 85633779,
+    "placetype": "country",
+    "name": "Slovenia",
+    "spoken": [
+      "slv"
+    ],
+    "official": [
+      "slv"
+    ]
+  },
+  "85632395": {
+    "id": 85632395,
+    "placetype": "country",
+    "name": "Belarus",
+    "spoken": [
+      "bel",
+      "rus"
+    ],
+    "official": [
+      "bel",
+      "rus"
+    ]
+  },
+  "85632403": {
+    "id": 85632403,
+    "placetype": "country",
+    "name": "Taiwan",
+    "spoken": [
+      "zho"
+    ],
+    "official": [
+      "zho"
+    ]
+  }
+}

--- a/src/data/aliases/country-language-map.sql
+++ b/src/data/aliases/country-language-map.sql
@@ -1,0 +1,23 @@
+/*
+  this SQL script can be used to regenerate the 'country-language-map.json' file.
+
+  at time of writing the required 'whosonfirst-data-country-latest.db' file isn't
+  distributed by Geocode Earth, you can generate it manually from the bundle file:
+
+  > aria2c https://data.geocode.earth/wof/dist/legacy/whosonfirst-data-country-latest.tar.bz2
+  > npm i @whosonfirst/wof
+  > wof bundle export whosonfirst-data-country-latest.tar.bz2 | wof sqlite import whosonfirst-data-country-latest.db
+*/
+
+SELECT json_group_object(id, json)
+FROM (
+  SELECT *, json_object(
+    'id', id,
+    'placetype', json_extract(body, '$.properties.wof:placetype'),
+    'name', json_extract(body, '$.properties.wof:name'),
+    'spoken', IFNULL(json_extract(body, '$.properties.wof:lang_x_spoken'), json_array()),
+    'official', IFNULL(json_extract(body, '$.properties.wof:lang_x_official'), json_array())
+  ) AS json
+  FROM geojson
+  WHERE json_extract(body, '$.properties.mz:is_current') == 1
+);

--- a/src/data/aliases/extract-aliases.js
+++ b/src/data/aliases/extract-aliases.js
@@ -1,0 +1,60 @@
+const _ = require('lodash');
+const { stream, whosonfirst } = require('@whosonfirst/wof');
+
+/**
+ * this script can be used to generate '*-endonyms.psv' files from
+ * whosonfirst bundle files.
+ *
+ * note: I've not included the dependencies in package.json since
+ * this script is seldom run: npm install @whosonfirst/wof
+ */
+
+// reduce the language map to a key/value dict where the key
+// is the wofid and the value is an array containing all unique language tags.
+const languageMap = _.pickBy(
+  _.mapValues(require('./country-language-map'), (config) => {
+    return _.union(/*config.spoken, */config.official);
+  }),
+  _.negate(_.isEmpty)
+);
+
+// extract endonyms from target bundle file
+const BUNDLE_FILE = '/data/wof/whosonfirst-data-country-latest.tar.bz2';
+// const BUNDLE_FILE = '/data/wof/whosonfirst-data-locality-latest.tar.bz2'
+
+stream.bsdtar.extract('-f', BUNDLE_FILE, '--include', '*.geojson', '--exclude', '*-alt-*')
+  .pipe(stream.json.parse())
+  .pipe(stream.miss.through.obj((feature, enc, next) => {
+    if (!whosonfirst.feature.isCurrent()) { return next(); }
+    if (whosonfirst.feature.isAltGeometry()) { return next(); }
+    // if (_.get(feature, 'properties.wof:megacity') !== 1) { return next() }
+
+    // find which country the feature belongs to
+    const countryID = _.get(feature, 'properties.wof:hierarchy[0].country_id');
+    if (!countryID) { return next(); }
+
+    // find all endonyms for the feature
+    // ie. place names in all official local languages
+    const endonyms = _.pickBy(
+      _.get(feature, 'properties'),
+      (v, k) => {
+        // if (k === `name:eng_x_preferred`) { return true }
+        const matches = k.match(/name:([a-z]{3})_x_preferred/);
+        if (!matches) { return false; }
+        return _.get(languageMap, countryID, []).includes(matches[1]);
+      }
+    );
+    if (_.isEmpty(endonyms)) { return next(); }
+
+    // whosonfirst can be verbose, so only select the first toponym
+    // per language. ie. there can be at most one alias per language code.
+    const flattened = _.uniq(_.values(_.mapValues(endonyms, _.first)));
+
+    // find WOF ID
+    const wofID = whosonfirst.feature.getID(feature);
+
+    // write out pipe-seperated list
+    console.log(_.concat(wofID, _.sortBy(flattened)).join('|'));
+
+    next();
+  }));

--- a/src/data/aliases/extract-aliases.js
+++ b/src/data/aliases/extract-aliases.js
@@ -38,7 +38,7 @@ stream.bsdtar.extract('-f', BUNDLE_FILE, '--include', '*.geojson', '--exclude', 
     const endonyms = _.pickBy(
       _.get(feature, 'properties'),
       (v, k) => {
-        // if (k === `name:eng_x_preferred`) { return true }
+        if (k === `name:eng_x_preferred`) { return true; }
         const matches = k.match(/name:([a-z]{3})_x_preferred/);
         if (!matches) { return false; }
         return _.get(languageMap, countryID, []).includes(matches[1]);

--- a/src/data/aliases/locality-megacity-endonyms.psv
+++ b/src/data/aliases/locality-megacity-endonyms.psv
@@ -1,200 +1,252 @@
 102000853|Torreón
 102001097|Mérida
-101996369|Querétaro
+101996369|Queretaro|Querétaro
 101996837|León
-102026311|대전
-101752771|Köln
-101748099|Antwerpen|Anvers
-101752703|Milano
-101999639|Puebla
-101994137|Chihuahua
+102026311|Daejon|대전
+101752771|Cologne|Köln
+101748099|Antwerp|Antwerpen|Anvers
+101752703|Milan|Milano
+101999639|Puebla|Puebla City
+101994137|Chihuahua|Chihuahua City
 101997865|Guadalajara
-102026291|울산
+102026291|Ulsan|울산
 102000679|Monterrey
 101991705|Toluca
 101993551|Tijuana
 101993731|Culiacán
 101996839|Aguascalientes
-102026447|인천
-102026391|광주
+102026447|Incheon|인천
+102026391|Gwangju|광주
 101752093|Porto
-102008123|Ленинград
-102002575|Великий Новгород
-102002947|Нижний Новгород
+102008123|Saint Petersburg|Ленинград
+102002575|Veliky Novgorod|Великий Новгород
+102002947|Nizhniy Novgorod|Нижний Новгород
 101913923|Glasgow
 101913933|Liverpool
 101913947|Manchester
 101913781|Łódź
 101751917|Oslo
-101752329|ΑΘΗΝΑΙ
+101752329|Athens|ΑΘΗΝΑΙ
 101914333|Auckland
+102020439|Jakarta
 101925753|Johannesburg
 101748799|Berlin
-101752331|Θεσσαλονίκη
-101996483|San Luis Potosí
+101752331|Thessaloniki|Θεσσαλονίκη
+101996483|S. Luis Potosi|San Luis Potosí
 101993461|Mexicali
 101955041|Valparaíso
-101752697|Torino
-102013953|Красноярск
-102005387|Воронеж
+101752697|Torino|Turin
+102013953|Krasnoyarsk|Красноярск
+102005387|Voronezh|Воронеж
 101751843|Rotterdam
-102012393|Омск
-102012947|Новосибирск
-1175613483|Нижний Новгород
-101994153|Ciudad Juárez
-1175612731|Αθήνα
-101752607|Roma
+102012393|Omsk|Омск
+102012947|Novo-Nikolaevsk|Новосибирск
+1175613483|Nizhniy Novgorod|Нижний Новгород
+101994153|Ciudad Juarez|Ciudad Juárez
+1175612731|Athens|Αθήνα
+101752607|Roma|Rome
 890437681|Montevideo
 101751703|Budapest
-101748479|München
-101749159|København
+101748479|Munich|München
+101749159|Copenhagen|København
 101752307|Stockholm
 101752181|Wrocław
 1495123997|Oslo
-101752555|Napoli
+101752555|Naples|Napoli
 101748841|Hamburg
-421168693|חיפה|حيفا
+102027757|Baoding
+421168693|Haifa|חיפה|حيفا
 101750547|Liverpool
 101750617|Newcastle upon Tyne
-1175613621|Великий Новгород
+1175613621|Veliky Novgorod|Великий Новгород
+102026859|Lu'an
+102027111|Tangshan
+102027225|Qinhuangdao
+102027425|Kaifengshi
+102027615|Foshan
 85947523|Louisville
 101749273|Nice
 101750277|Lille
 101750691|Toulouse
-101946905|João Pessoa
-101954595|Vitória
-101964301|Santa Catarina
+102027127|Tai'an
+102027169|Shaoxing
+102027279|Nantong
+102027341|Luoyang
+102027471|Jiaxing
+102027709|Changzhou
+102027851|Yingkou
+102027885|Mudanjiang
+102027929|Fushun
+101946905|Joao Pessoa|João Pessoa
+101954595|Vitoria|Vitória
+101964301|Joinville|Santa Catarina
+102027037|Zhuhai
 85923951|San Bernardino
 101750525|Manchester
+102026967|Yantai
+102026983|Xuzhou
+102027043|Amoy
+102027049|Wuxi
+102027901|Jilin
 85917235|Tucson
 85933091|Orlando
 101724863|El Paso
 101750467|Birmingham
-102007285|Ростов-на-Дону
-421166941|المدينة
-101752117|Kraków
-102005377|Воронеж
-102011123|Саратов
-102012335|Челябинск
-102012351|Омск
+102007285|Rostov-on-Don|Ростов-на-Дону
+421166941|Medina|المدينة
+101752117|Krakow|Kraków
+102005377|Voronezh|Воронеж
+102011123|Saratov|Саратов
+102012335|Chelyabinsk|Челябинск
+102012351|Omsk|Омск
+102027161|Shijiazhuang
+102027561|Hefei
 101748979|Bordeaux
 101749199|Marseille
-101943433|São Luís
-421202467|بصرة
+101943433|Sao Luis|São Luís
+102027067|Wenzhou
+102027273|Ningbo
+102027669|Dalian
+102027913|Hohhot
+421202467|Basra|بصرة
 85974801|Las Vegas
 101724653|San Antonio
 101722645|Memphis
 421199773|Lomé
-102002899|Нижний Новгород
-102006827|Волгоград
-102009691|Уфа
-102011627|Самара
-102011881|Екатеринбург
-421168831|काठमाडौं
+102002899|Nizhny Novgorod|Нижний Новгород
+102006827|Volgograd|Волгоград
+102009691|Ufa|Уфа
+102011627|Samara|Самара
+102011881|Yekaterinburg|Екатеринбург
+421168831|Kathmandu|काठमाडौं
 421173057|Tegucigalpa
 421173185|Kampala
 421176527|Port-au-Prince|Pòtoprens
 421176817|Freetown
 421197251|Niamey
 890444507|Rabat|رباط
-890445081|Ciudad de Panamá
+890445081|Ciudad de Panamá|Panama City
 1175612707|Glasgow
 101748241|Valencia
 101749431|Lyon
-102008455|Пермь
-102012919|Новосибирск
-102013949|Красноярск
-421168899|Бишкек
+102008455|Molotov|Пермь
+102012919|Novosibirsk|Новосибирск
+102013949|Krasnoyarsk|Красноярск
+102026957|Yinchuan
+102027001|Xining
+102027175|Shantou
+102027593|Guilin
+421168899|Bishkek|Бишкек
 421173233|Kitu|Quito
 421181453|Antananarivo
-421186169|Улаанбаатар
-421200421|عمّان
+421186169|Ulan Bator|Улаанбаатар
+421200421|Amman|عمّان
 890437283|Abuja|Abùjá
-890449737|Muqdisho|مقديشو
+890449737|Mogadishu|Muqdisho|مقديشو
 101941913|Manaus
-101958175|Florianópolis
+101958175|Florianopolis|Florianópolis
 101961475|Campo Grande
-421169087|Ciudad de Guatemala
-421176003|Алма-Ата|Алматы
+421169087|Ciudad de Guatemala|Guatemala City
+421176003|Almaty|Алма-Ата|Алматы
 421180023|Brazzaville
 421182167|Bamako
 421189675|Conakry
-890442383|بيروت
-890443227|თბილისი
+890442383|Beirut|بيروت
+890443227|Tbilisi|თბილისი
 890458845|Calgary
 101934019|Brisbane
 101935721|Adelaide
 421168983|Ouagadougou
 421169001|Cotonou
-421174967|Bakı
-421182367|Երեվան
+421174967|Baku|Bakı
+421182367|Yerevan|Երեվան
 421204495|Yaoundé
-890443331|Горад Мінск|Минск
-890445571|Naypyidaw
+890443331|Minsk|Горад Мінск|Минск
+890445571|Naypyidaw|Naypyitaw
 85922227|San Diego
 101730401|Seattle
 101724385|Dallas
 85931789|Tampa
 101748323|Barcelona
-421177479|Hà Nội
-421203883|صنعاء
+421177479|Hanoi|Hà Nội
+421203883|Sanaa|صنعاء
 890460453|Ankara
-421186583|La Habana
+102027287|Nanning
+102027397|Lanzhou
+102027585|Guiyang
+102027611|Fuzhou
+102027633|Dongguan
+102027689|Chongqing
+421186583|Havana|La Habana
 421195425|Monrovia
-1158857531|Санкт-Петербург
+1158857531|Saint Petersburg City|Санкт-Петербург
+102026899|Zhengzhou
+102027061|Wuhan
+102027117|Taiyuan
+102027291|Nanjing
+102027295|Nanchangshi
+102027417|Kunming
+102027459|Jinan
+102027571|Hangzhou
+102027875|Shenyang
+102027921|Harbin
+102027947|Changchun
 421168965|Accra
-421194651|طرابلس
+421194651|Tripoli|طرابلس
 890429209|Santo Domingo
-101942553|Belém
+101942553|Belem|Belém
 101960525|Porto Alegre
 421199985|Abidjan
 101937679|Perth
-421174649|Alger|الجزائر
+421174649|Alger|Algiers|الجزائر
 85933669|Miami
 101725629|Houston
+102026823|Urumqi
+102027703|Chengdu
 421166913|Kinshasa
-421168855|Toshkent
-421174961|دبي
+421168855|Tashkent|Toshkent
+421174961|Dubai|دبي
 421186805|Lima
 421199619|Dakar|Ndakaaru
 890442147|Caracas
 1159397249|Manila
-421170391|አዲስ አበባ
-421204533|تهران
+421170391|Addis Ababa|አዲስ አበባ
+421204533|Tehran|تهران
 101933229|Melbourne
-421168799|کابل
-102003033|Москва
+421168799|Kabul|کابل
+102003033|Moscow|Москва
+102027745|Beijing
 101751119|Paris
 421174401|Nairobi
 421186687|Bogotá
 101914257|Auckland|Tāmaki-makau-rau
 101932003|Sydney
-1125853197|ភ្នំពេញ
+1125853197|Phnom Penh|ភ្នំពេញ
 101912923|Antalya
-421199765|بنغازي
-421186153|الموصل
-1141908681|أربيل
-890451605|남포
+421199765|Benghazi|بنغازي
+421186153|Mosul|الموصل
+1141908681|Erbil|أربيل
+890451605|Nampho|남포
 890435387|Marrakech|مراكش
 890442173|Santa Cruz de la Sierra|Santa Krus|Santa Krus llaqta
-421168643|اهواز
-421168719|Eşfehān
-421181507|کرج
-421193175|تبریز
-421179271|شیراز
-1125929605|مشهد
-421168821|রাজশাহী
-890449743|تعز
-890432439|الحديدة
+421168643|Ahvaz|اهواز
+421168719|Eşfehān|Isfahan
+421181507|Karaj|کرج
+421193175|Tabriz|تبریز
+421179271|Shiraz|شیراز
+1125929605|Mashhad|مشهد
+421168821|Rajshahi|রাজশাহী
+890449743|Ta'izz|تعز
+890432439|Al Hudaydah|الحديدة
 890463545|Konya
-890461083|İzmir
+890461083|Izmir|İzmir
 890461315|Bursa
 890461703|Adana
 421189877|Douala
 890445225|Arequipa|Arikipa
 421189991|Mombasa
 421168647|Homs|حمص
-421202163|Alep|حلب
+421202163|Alep|Aleppo|حلب
 421168921|Davao City
 421198057|Lubumbashi
 1141909257|Mbuji-Mayi
@@ -202,7 +254,7 @@
 421189813|Dar es Salaam
 421186705|Guayaquil|Wayakil
 421168961|Kumasi
-890429453|الإسكندرية
+890429453|Alexandria|الإسكندرية
 890444579|Huambo
 421172797|San Miguel de Tucumán
 421168975|Maiduguri
@@ -212,14 +264,21 @@
 890434619|Ilorin
 890444289|Zaria
 1125988111|Ibadan|Ìbàdàn
-421176809|Thành phố Hồ Chí Minh
-890440107|Hải Phòng
+890516077|Yichun
+890516067|Benxi
+890513543|Zhaotong
+890512599|Fuxin
+890512899|Lianshan
+890512925|Zaozhuang
+890515729|Handan
+421176809|Ho Chi Minh City|Thành phố Hồ Chí Minh
+890440107|Haiphong|Hải Phòng
 890443751|Yangon
 421186751|Valencia
 890440177|Barquisimeto
 890442137|Maracaibo
 421169145|Santiago de Cali
-421181367|Cartagena de Indias
+421181367|Cartagena|Cartagena de Indias
 890442155|Medellín
 890444993|Bucaramanga
 890445001|Barranquilla
@@ -241,7 +300,7 @@
 85977539|New York
 85977591|Rochester
 85978023|Buffalo
-421202465|مدينة الكويت
+421202465|Kuwait City|مدينة الكويت
 101712381|Columbus
 101723183|Nashville
 101724577|Austin
@@ -253,138 +312,221 @@
 85937601|Urban Honolulu
 85942569|Indianapolis
 85950361|Boston
-102018433|Kota Medan
-102018665|Kota Makassar
-102018911|Kota Surabaya
-102019121|Kota Semarang
-102019475|Kota Pekanbaru
-102019607|Kota Palembang
-102019633|Kota Padang
-102019893|Kabupaten Malang
-102021015|Kota Bandung
-421172813|Ciudad de Córdoba
-890440301|N'Djaména|إنجامينا
-102031499|名古屋
-102031919|仙台
-102032015|札幌
-421188981|평양
-890442051|함흥
+102018433|Kota Medan|Medan
+102018665|Kota Makassar|Ujungpandang
+102018911|Kota Surabaya|Surabaya
+102019121|Kota Semarang|Semarang
+102019475|Kota Pekanbaru|Pekanbaru
+102019607|Kota Palembang|Palembang
+102019633|Kota Padang|Padang
+102019893|Kabupaten Malang|Malang
+102021015|Bandung|Kota Bandung
+421172813|Ciudad de Córdoba|Córdoba
+890440301|N'Djamena|N'Djaména|إنجامينا
+102031499|Nagoya-shi|名古屋
+102031919|Sendai-shi|仙台
+102032015|Sapporo-shi|札幌
+421188981|Pyongyang|평양
+890442051|Hamhung|함흥
+102022781|Johor Bahru
 102000871|Saltillo
-421190143|Ville Nouvelle|فاس
-101751949|Bucureşti
-101752799|Одеса|Одесса
-101752845|Запорожье|Запоріжжя
-101752963|Харків|Харьков
-101752861|Днепр|Дніпро
-101752891|Донецк|Донецьк
+421190143|Fes|Ville Nouvelle|فاس
+101751949|Bucharest|Bucureşti
+101752799|Odesa|Одеса|Одесса
+101752845|Zaporozhye|Запорожье|Запоріжжя
+101752963|Kharkiv|Харків|Харьков
+101752861|Dnipropetrovs'k|Днепр|Дніпро
+101752891|Donetsk|Донецк|Донецьк
 101714461|Oklahoma City
 101728745|Virginia Beach
-101964877|Brasília
+101964877|Brasilia|Brasília
+102027597|Guangzhou
 101943607|Teresina
-101748113|Praha
-857683023|Ciudad de México
+101748113|Prague|Praha
+857683023|Ciudad de México|Mexico City
 1125905513|Asunción|Paraguay
-102026353|부산
-102026521|성남
+102026353|Busan|부산
+102026521|Seongnam-si|성남
+102027107|Tianjin
+102027715|Changsha
 101751893|Amsterdam
 85936429|Atlanta
-102031735|広島
+102031735|Hiroshima-shi|広島
 101748417|Helsingfors|Helsinki
 101957995|Curitiba
 1175610569|Brussel|Bruxelles|Brüssel
+102025263|Bangkok
 85948111|New Orleans
-101961233|Cuiabá
+101961233|Cuiaba|Cuiabá
 890458485|Edmonton
-102031307|東京
-101948377|Maceió
+102031307|Tokyo|東京
+101948377|Maceio|Maceió
 101913783|Łódź
 101948979|Belo Horizonte
-421174285|Ciudad Autónoma de Buenos Aires
+421174285|Buenos Aires|Ciudad Autónoma de Buenos Aires
+102022835|Klang
 101956069|Campinas
-102026641|T’ai-pei
-102026643|臺南市
+102026641|Taipei|T’ai-pei
+102026643|Tainan City|臺南市
 890437279|Hong Kong|香港
-102031795|福岡
+102031795|Fukuoka-shi|福岡
 101750579|Leeds
-890476941|Београд
-102026649|臺中市
+890476941|Belgrade|Београд
+102026649|Taichung|臺中市
 101736545|Montreal|Montréal
-102031439|大阪
-102026355|부천
+102031439|Osaka-shi|大阪
+102026355|Bucheon-Si|부천
 101965655|Santos
 101750367|London
 101944733|Fortaleza
+102027181|Shanghai
+102027165|Shenzhen
 101735835|Toronto
-102026323|수원
-102026327|서울
+102016833|Valparaíso
+102026323|Suwon|수원
+102026327|Seoul|서울
 421171291|Kigali
-421174399|القاهرة
-102031567|京都
-102026315|대구
-421178393|بغداد
+421174399|Cairo|القاهرة
+102031567|Kyoto-shi|京都
+102026315|Daegu|대구
+102023407|Kuala Lumpur
+421178393|Baghdad|بغداد
 101741075|Vancouver
-101968251|Goiânia
+101968251|Goiania|Goiânia
+102027041|Hsi-an
 101748463|Zurich|Zurigo|Züri|Zürich
-101752777|Warszawa
+101752777|Warsaw|Warszawa
 101948669|Recife
 101950447|Salvador
 101965533|São Paulo
 102032341|Singapore|Singapura|சிங்கப்பூர்|新加坡
-101748073|Wien
-421190297|الدمام
-421200923|جدة
-421204501|الرياض
-421204201|مكة
-890460455|İstanbul
+101748073|Vienna|Wien
+421190297|Dammam|الدمام
+421200923|Jeddah|جدة
+421204501|Riyadh|الرياض
+421204201|Mecca|مكة
+890460455|Istanbul|İstanbul
 101735873|Ottawa
+102016915|Santiago
 421176731|Chuqi Yapu|Chuqiyapu|La Paz
-421166963|کرمانشاه
-421199797|قم
-421174123|খুলনা
-421181477|ঢাকা
-421199663|চট্টগ্রাম
+421166963|Kermanshah|کرمانشاه
+421199797|Qom|قم
+421174123|Khulna|খুলনা
+421181477|Dhaka|ঢাকা
+421199663|Chittagong|চট্টগ্রাম
 890441687|Khartoum|خرطوم
 101953261|Rio de Janeiro
 101946845|Natal
 101958341|Santiago
 101752517|Palermo
-102009145|Казань
-102026411|고양
+102009145|Kazan’|Казань
+102026411|Goyang-Si|고양
 85922845|Sacramento
 85932547|Jacksonville
 85922347|San Jose
 101715829|Portland
 101728675|Richmond
 890461631|Gaziantep
-421202165|Damas|دمشق
+421202165|Damas|Damascus|دمشق
 421191785|San Salvador
-101748887|София
-102026701|高雄市
+101748887|Sofia|София
+102026701|Kaohsiung City|高雄市
 421175823|City of Cebu
 890429511|Zamboanga City
 421170449|Oran|وهران
 421167893|Maputo
 421178937|Lusaka
 421201479|Harare
-102020817|Kota Bogor
-102018833|Kota Bandar Lampung
+102020817|Bogor|Kota Bogor
+102018833|Kota Bandar Lampung|Tanjungkarang
 890432155|Luanda
-1125955239|תל אביב-יפו|تل أبيب
+1125955239|Tel Aviv|תל אביב-יפו|تل أبيب
+101919427|San Juan
 421172799|Rosario
-421200319|Ciudad de Mendoza
+421200319|Ciudad de Mendoza|Mendoza
 890437281|Lagos|Èkó
 1125880387|Kaduna|Kàdúná
 1141909213|Ogbomosho|Ògbómọ̀ṣọ́
-101752087|Lisboa
+101752087|Lisboa|Lisbon
 101748283|Madrid
 890451731|Managua
-890443763|မန္တလေးမြို့
+102027309|Mianyang
+102027103|Tianshui City
+102027939|Dandong
+102027953|Baotou
+102027991|Xingyi
+102027337|Luzhou
+102027535|Huaibei
+102027937|Daqing
+102027827|Yueyangshi
+102027829|Yulin
+102027091|Weifang
+102027275|Neijiang
+102027881|Qiqihar
+102027031|Xianyang
+102027261|Pingdingshan
+102027497|Huzhou
+102027895|Jixi
+102027293|Nanchong
+102027039|Xiangfan
+102027867|Tongliao
+102027379|Linfen
+102027371|Linyi
+102027543|Heze
+102027545|Yiyang
+102027777|Suzhou
+102027767|Anshun
+102027935|Datongshi
+102027961|Anshan
+102027369|Liuzhou
+102027531|Huainan
+102027553|Hengyang
+102027905|Jiamusi
+102027277|Nanyang
+102027613|Fuyang District
+102027215|Zayton
+102027241|Qingdao
+102027443|Jining
+102027473|Jiaozuo
+102027815|Anyang
+102027847|Zhangjiakou
+102027059|Wuhu
+102027451|Jingmen
+102027891|Liaoyang
+102027057|Changde
+102027403|Langfang
+102027743|Bengbu
+102027899|Jinzhou
+102027389|Leshan
+102027943|Chifeng
+102026963|Yichangshi
+102026965|Yibin
+102026991|Xinyu
+102026873|Zunyi
+102026875|Zigong
+102026949|Yuci
+102026977|Yancheng
+102026959|Yichun
+102026993|Xinxiang
+102026877|Jianning
+102026897|Chinkiang
+102026911|Zhanjiang
+102026921|Zibo
+890516983|Xuancheng
+890516653|Huai'an
+890512887|Pingxiang
+890512889|Xiantao
+890512901|Lingyuan
+890512341|Xinyang
+890512923|Shangqiu
+1141908643|Yongzhou
+890443763|Mandalay|မန္တလေးမြို့
 421171925|San José
 421181395|Maracay
 85981333|Charlotte
 101751737|Baile Átha Cliath|Dublin
 85922583|San Francisco
-101752489|Киев|Київ
+101752489|Kyiv|Киев|Київ
 890434661|Casablanca|الدار البيضاء
 1763179367|Johannesburg
 101925471|Pretoria

--- a/src/data/aliases/locality-megacity-endonyms.psv
+++ b/src/data/aliases/locality-megacity-endonyms.psv
@@ -1,0 +1,466 @@
+102000853|Torreón
+102001097|Mérida
+101996369|Querétaro
+101996837|León
+102026311|대전
+101752771|Köln
+101748099|Antwerpen|Anvers
+101752703|Milano
+101999639|Puebla
+101994137|Chihuahua
+101997865|Guadalajara
+102026291|울산
+102000679|Monterrey
+101991705|Toluca
+101993551|Tijuana
+101993731|Culiacán
+101996839|Aguascalientes
+102026447|인천
+102026391|광주
+101752093|Porto
+102008123|Ленинград
+102002575|Великий Новгород
+102002947|Нижний Новгород
+101913923|Glasgow
+101913933|Liverpool
+101913947|Manchester
+101913781|Łódź
+101751917|Oslo
+101752329|ΑΘΗΝΑΙ
+101914333|Auckland
+101925753|Johannesburg
+101748799|Berlin
+101752331|Θεσσαλονίκη
+101996483|San Luis Potosí
+101993461|Mexicali
+101955041|Valparaíso
+101752697|Torino
+102013953|Красноярск
+102005387|Воронеж
+101751843|Rotterdam
+102012393|Омск
+102012947|Новосибирск
+1175613483|Нижний Новгород
+101994153|Ciudad Juárez
+1175612731|Αθήνα
+101752607|Roma
+890437681|Montevideo
+101751703|Budapest
+101748479|München
+101749159|København
+101752307|Stockholm
+101752181|Wrocław
+1495123997|Oslo
+101752555|Napoli
+101748841|Hamburg
+421168693|חיפה|حيفا
+101750547|Liverpool
+101750617|Newcastle upon Tyne
+1175613621|Великий Новгород
+85947523|Louisville
+101749273|Nice
+101750277|Lille
+101750691|Toulouse
+101946905|João Pessoa
+101954595|Vitória
+101964301|Santa Catarina
+85923951|San Bernardino
+101750525|Manchester
+85917235|Tucson
+85933091|Orlando
+101724863|El Paso
+101750467|Birmingham
+102007285|Ростов-на-Дону
+421166941|المدينة
+101752117|Kraków
+102005377|Воронеж
+102011123|Саратов
+102012335|Челябинск
+102012351|Омск
+101748979|Bordeaux
+101749199|Marseille
+101943433|São Luís
+421202467|بصرة
+85974801|Las Vegas
+101724653|San Antonio
+101722645|Memphis
+421199773|Lomé
+102002899|Нижний Новгород
+102006827|Волгоград
+102009691|Уфа
+102011627|Самара
+102011881|Екатеринбург
+421168831|काठमाडौं
+421173057|Tegucigalpa
+421173185|Kampala
+421176527|Port-au-Prince|Pòtoprens
+421176817|Freetown
+421197251|Niamey
+890444507|Rabat|رباط
+890445081|Ciudad de Panamá
+1175612707|Glasgow
+101748241|Valencia
+101749431|Lyon
+102008455|Пермь
+102012919|Новосибирск
+102013949|Красноярск
+421168899|Бишкек
+421173233|Kitu|Quito
+421181453|Antananarivo
+421186169|Улаанбаатар
+421200421|عمّان
+890437283|Abuja|Abùjá
+890449737|Muqdisho|مقديشو
+101941913|Manaus
+101958175|Florianópolis
+101961475|Campo Grande
+421169087|Ciudad de Guatemala
+421176003|Алма-Ата|Алматы
+421180023|Brazzaville
+421182167|Bamako
+421189675|Conakry
+890442383|بيروت
+890443227|თბილისი
+890458845|Calgary
+101934019|Brisbane
+101935721|Adelaide
+421168983|Ouagadougou
+421169001|Cotonou
+421174967|Bakı
+421182367|Երեվան
+421204495|Yaoundé
+890443331|Горад Мінск|Минск
+890445571|Naypyidaw
+85922227|San Diego
+101730401|Seattle
+101724385|Dallas
+85931789|Tampa
+101748323|Barcelona
+421177479|Hà Nội
+421203883|صنعاء
+890460453|Ankara
+421186583|La Habana
+421195425|Monrovia
+1158857531|Санкт-Петербург
+421168965|Accra
+421194651|طرابلس
+890429209|Santo Domingo
+101942553|Belém
+101960525|Porto Alegre
+421199985|Abidjan
+101937679|Perth
+421174649|Alger|الجزائر
+85933669|Miami
+101725629|Houston
+421166913|Kinshasa
+421168855|Toshkent
+421174961|دبي
+421186805|Lima
+421199619|Dakar|Ndakaaru
+890442147|Caracas
+1159397249|Manila
+421170391|አዲስ አበባ
+421204533|تهران
+101933229|Melbourne
+421168799|کابل
+102003033|Москва
+101751119|Paris
+421174401|Nairobi
+421186687|Bogotá
+101914257|Auckland|Tāmaki-makau-rau
+101932003|Sydney
+1125853197|ភ្នំពេញ
+101912923|Antalya
+421199765|بنغازي
+421186153|الموصل
+1141908681|أربيل
+890451605|남포
+890435387|Marrakech|مراكش
+890442173|Santa Cruz de la Sierra|Santa Krus|Santa Krus llaqta
+421168643|اهواز
+421168719|Eşfehān
+421181507|کرج
+421193175|تبریز
+421179271|شیراز
+1125929605|مشهد
+421168821|রাজশাহী
+890449743|تعز
+890432439|الحديدة
+890463545|Konya
+890461083|İzmir
+890461315|Bursa
+890461703|Adana
+421189877|Douala
+890445225|Arequipa|Arikipa
+421189991|Mombasa
+421168647|Homs|حمص
+421202163|Alep|حلب
+421168921|Davao City
+421198057|Lubumbashi
+1141909257|Mbuji-Mayi
+1141909255|Kananga
+421189813|Dar es Salaam
+421186705|Guayaquil|Wayakil
+421168961|Kumasi
+890429453|الإسكندرية
+890444579|Huambo
+421172797|San Miguel de Tucumán
+421168975|Maiduguri
+421180027|Port Harcourt
+421189725|Benin City|Ìlú Benin
+890432249|Kano|Kánò
+890434619|Ilorin
+890444289|Zaria
+1125988111|Ibadan|Ìbàdàn
+421176809|Thành phố Hồ Chí Minh
+890440107|Hải Phòng
+890443751|Yangon
+421186751|Valencia
+890440177|Barquisimeto
+890442137|Maracaibo
+421169145|Santiago de Cali
+421181367|Cartagena de Indias
+890442155|Medellín
+890444993|Bucaramanga
+890445001|Barranquilla
+101712161|Dayton
+101712203|Cincinnati
+101712563|Cleveland
+101718083|Philadelphia
+101718805|Pittsburgh
+101720571|East Providence
+101732987|Milwaukee
+85923517|Los Angeles
+85930811|Bridgeport
+85940195|Chicago
+85949461|Baltimore
+85951091|Detroit
+85969169|Minneapolis
+85970739|Kansas City
+85971343|St. Louis
+85977539|New York
+85977591|Rochester
+85978023|Buffalo
+421202465|مدينة الكويت
+101712381|Columbus
+101723183|Nashville
+101724577|Austin
+101728075|Salt Lake City
+85917479|Phoenix
+85928879|Denver
+85930819|Hartford
+85931779|Washington
+85937601|Urban Honolulu
+85942569|Indianapolis
+85950361|Boston
+102018433|Kota Medan
+102018665|Kota Makassar
+102018911|Kota Surabaya
+102019121|Kota Semarang
+102019475|Kota Pekanbaru
+102019607|Kota Palembang
+102019633|Kota Padang
+102019893|Kabupaten Malang
+102021015|Kota Bandung
+421172813|Ciudad de Córdoba
+890440301|N'Djaména|إنجامينا
+102031499|名古屋
+102031919|仙台
+102032015|札幌
+421188981|평양
+890442051|함흥
+102000871|Saltillo
+421190143|Ville Nouvelle|فاس
+101751949|Bucureşti
+101752799|Одеса|Одесса
+101752845|Запорожье|Запоріжжя
+101752963|Харків|Харьков
+101752861|Днепр|Дніпро
+101752891|Донецк|Донецьк
+101714461|Oklahoma City
+101728745|Virginia Beach
+101964877|Brasília
+101943607|Teresina
+101748113|Praha
+857683023|Ciudad de México
+1125905513|Asunción|Paraguay
+102026353|부산
+102026521|성남
+101751893|Amsterdam
+85936429|Atlanta
+102031735|広島
+101748417|Helsingfors|Helsinki
+101957995|Curitiba
+1175610569|Brussel|Bruxelles|Brüssel
+85948111|New Orleans
+101961233|Cuiabá
+890458485|Edmonton
+102031307|東京
+101948377|Maceió
+101913783|Łódź
+101948979|Belo Horizonte
+421174285|Ciudad Autónoma de Buenos Aires
+101956069|Campinas
+102026641|T’ai-pei
+102026643|臺南市
+890437279|Hong Kong|香港
+102031795|福岡
+101750579|Leeds
+890476941|Београд
+102026649|臺中市
+101736545|Montreal|Montréal
+102031439|大阪
+102026355|부천
+101965655|Santos
+101750367|London
+101944733|Fortaleza
+101735835|Toronto
+102026323|수원
+102026327|서울
+421171291|Kigali
+421174399|القاهرة
+102031567|京都
+102026315|대구
+421178393|بغداد
+101741075|Vancouver
+101968251|Goiânia
+101748463|Zurich|Zurigo|Züri|Zürich
+101752777|Warszawa
+101948669|Recife
+101950447|Salvador
+101965533|São Paulo
+102032341|Singapore|Singapura|சிங்கப்பூர்|新加坡
+101748073|Wien
+421190297|الدمام
+421200923|جدة
+421204501|الرياض
+421204201|مكة
+890460455|İstanbul
+101735873|Ottawa
+421176731|Chuqi Yapu|Chuqiyapu|La Paz
+421166963|کرمانشاه
+421199797|قم
+421174123|খুলনা
+421181477|ঢাকা
+421199663|চট্টগ্রাম
+890441687|Khartoum|خرطوم
+101953261|Rio de Janeiro
+101946845|Natal
+101958341|Santiago
+101752517|Palermo
+102009145|Казань
+102026411|고양
+85922845|Sacramento
+85932547|Jacksonville
+85922347|San Jose
+101715829|Portland
+101728675|Richmond
+890461631|Gaziantep
+421202165|Damas|دمشق
+421191785|San Salvador
+101748887|София
+102026701|高雄市
+421175823|City of Cebu
+890429511|Zamboanga City
+421170449|Oran|وهران
+421167893|Maputo
+421178937|Lusaka
+421201479|Harare
+102020817|Kota Bogor
+102018833|Kota Bandar Lampung
+890432155|Luanda
+1125955239|תל אביב-יפו|تل أبيب
+421172799|Rosario
+421200319|Ciudad de Mendoza
+890437281|Lagos|Èkó
+1125880387|Kaduna|Kàdúná
+1141909213|Ogbomosho|Ògbómọ̀ṣọ́
+101752087|Lisboa
+101748283|Madrid
+890451731|Managua
+890443763|မန္တလေးမြို့
+421171925|San José
+421181395|Maracay
+85981333|Charlotte
+101751737|Baile Átha Cliath|Dublin
+85922583|San Francisco
+101752489|Киев|Київ
+890434661|Casablanca|الدار البيضاء
+1763179367|Johannesburg
+101925471|Pretoria
+101927971|Durban
+101926389|Vereeniging
+101925811|Benoni
+101929259|Gqeberha
+101928027|Cape Town
+101909779|Berlin
+102031017|Ahmedabad|अहमदाबाद
+102031021|Agra|आगरा
+102030157|Gwalior|ग्वालियर
+102030901|Asansol|आसनसोल
+102030997|Aligarh|अलीगढ़
+102030681|Bhiwandi|भिवंडी
+102030955|Amritsar|अमृतसर
+102030041|Indore|इंदौर
+102030289|Faridabad|फ़रीदाबाद
+102030425|Delhi|दिल्ली
+102030887|Aurangabad|औरंगाबाद
+102030673|Bhopal|भोपाल
+102030819|Bangalore|बेंगलुरु
+102030401|Dhanbad|धनबाद
+102030693|Bhilai|भिलाई
+102030233|Ghaziabad|गाज़ियाबाद
+102030995|Prayagraj|प्रयागराज
+102030563|Chandigarh|चंडीगढ़
+102030017|Jaipur|जयपुर
+102030029|Jabalpur|जबलपुर
+102030059|Hyderabad|हैदराबाद
+102030495|Coimbatore|कोयम्बटूर
+102030665|Bhubaneswar|भुवनेश्वर
+102030067|Hubballi|हुबली
+102030585|Kolkata|कोलकाता
+102030609|Mumbai|मुंबई
+102030781|Bareilly|बरेली
+102029533|Madurai|मदुरै
+102029991|Jammu|جموں
+102029167|North Guwahati|उत्तर गुवाहाटी
+102029557|Lucknow|लखनऊ
+102029219|Nashik|नासिक
+102029055|Patna|पटना
+102029669|Kota|कोटा
+102029941|Jalandhar|जालंधर
+102029983|Jamshedpur|जमशेदपुर
+102029947|Jodhpur|जोधपुर
+102029361|Moradabad|मुरादाबाद
+102029537|Chennai|चेन्नई
+102029303|Mysore|मैसूर
+102029555|Ludhiana|लुधियाना
+102029277|Nagpur|नागपुर
+102029641|Kozhikode|कोझिकोड
+102029855|Kanpur|कानपुर
+102029389|Meerut|मेरठ
+102028309|Varanasi|वाराणसी
+102028331|Vadodara|वड़ोदरा
+102028901|Rajkot|राजकोट
+102028965|Pune|पुणे
+102028441|Tiruchirappalli|तिरुचिरापल्ली
+102028261|Visakhapatnam|विशाखापट्नम
+102028861|Ranchi|रांची
+102028407|Thiruvananthapuram|तिरुवनंतपुरम
+102028657|Solapur|सोलापुर
+102028771|Salem|सेलेम
+102028539|Surat|सूरत
+102028565|Srinagar|سری نگر
+102028271|Vijayawada|विजयवाड़ा
+102028919|Raipur|रायपुर
+102030497|Kochi|कोच्ची
+421191105|Peshawar|پشاور
+421168811|Islamabad|اسلام آباد
+421168813|Hyderabad|حیدرآباد
+421173213|Rawalpindi|راولپنڈی
+421173215|Quetta|کوئٹہ
+421181503|Faisalabad|فیصل آباد
+421182299|Gujranwala|گجرانوالہ
+421191101|Karachi|کراچی
+421204525|Lahore|لاہور
+890443585|Multan|ملتان

--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -3,6 +3,7 @@ const parallelTransform = require('parallel-transform');
 const logger = require( 'pelias-logger' ).get( 'wof-admin-lookup' );
 const getAdminLayers = require( './getAdminLayers' );
 const usePostalCity = require( './usePostalCity' );
+const useEndonyms = require( './useEndonyms' );
 
 function hasAnyMultiples(result) {
   return Object.keys(result).some((element) => {
@@ -72,6 +73,11 @@ function createPipResolverStream(pipResolver, config) {
       // optionally enable/disable this functionality using config variable.
       if( config && true === config.usePostalCities ){
         usePostalCity( result, doc );
+      }
+
+      // add endonyms as aliases for places defined in the dictionaries.
+      if( config && true === config.useEndonyms ){
+        useEndonyms( result, doc );
       }
 
       callback(null, doc);

--- a/src/useEndonyms.js
+++ b/src/useEndonyms.js
@@ -1,0 +1,63 @@
+const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
+const peliasLogger = require('pelias-logger');
+const logger = peliasLogger.get('wof-admin-lookup');
+
+// load dictionary files
+const endonyms = {
+  country: loadEndonyms('country'),
+  locality: loadEndonyms('locality-megacity')
+};
+
+/**
+  This function appends additional endoymns as aliases for admin areas.
+
+  The PIP service traditionally only returned a single name for parents,
+  this causes issues where names from a foreign language are required.
+
+  When this module is enabled, it will add additional names for all
+  endonyms (ie. what the locals call a place).
+
+  This is particularly helpful when we use the English name by default
+  (eg. 'Germany') and so matching doesn't work equally when using the
+  term 'Deutschland' instead.
+**/
+function useEndonyms(result, doc) {
+  try {
+    // iterate over all dictionaries loaded above
+    _.each(endonyms, (mapping, placetype) => {
+
+      // find the parent ID and check for a corresponding alias map
+      let parentID = _.first(_.castArray(_.get(doc, `parent.${placetype}_id`, [])));
+      if (!_.has(mapping, parentID, [])) { return; } // no mapping for ID
+
+      // find parent source and ensure it is WOF (either explicitely or by omission)
+      let parentSrc = _.first(_.get(doc, `parent.${placetype}_source`, []));
+      if (!!parentSrc && parentSrc !== 'whosonfirst') { return; }
+
+      // add each alias which is not already defined
+      _.difference(
+        _.get(mapping, parentID, []),
+        _.castArray(_.get(doc, `parent.${placetype}`, []))
+      ).forEach(alias => {
+        // note: addParent can throw an error if, for example, alias is an empty string
+        doc.addParent(placetype, alias, parentID);
+      });
+    });
+  }
+  catch (err) {
+    logger.warn('failed to set endonym', err);
+  }
+}
+
+// load PSV file, lines are delimited by a newline, rows by a pipe.
+// the first column contains the WOFID and subsequent cells contain aliases
+function loadEndonyms(name) {
+  const filepath = path.resolve(__dirname, 'data/aliases', `${name}-endonyms.psv`);
+  logger.debug(`[useEndonyms] loaded ${filepath}`);
+  const rows = fs.readFileSync(filepath, 'utf8').trim().split('\n').map(r => r.split('|'));
+  return rows.reduce((dict, row) => ({ ...dict, [_.first(row)]: row.slice(1) }), {});
+}
+
+module.exports = useEndonyms;

--- a/test/lookupStreamEndonymsTest.js
+++ b/test/lookupStreamEndonymsTest.js
@@ -1,0 +1,74 @@
+const tape = require('tape');
+const event_stream = require('event-stream');
+const Document = require('pelias-model').Document;
+
+const stream = require('../src/lookupStream');
+
+function test_stream(input, testedStream, callback) {
+  const input_stream = event_stream.readArray(input);
+  const destination_stream = event_stream.writeArray(callback);
+
+  input_stream.pipe(testedStream).pipe(destination_stream);
+}
+
+tape('tests', (test) => {
+  test.test('endonyms - country - Germany/Deutschland', (t) => {
+    const inputDoc = new Document('whosonfirst', 'placetype', '1')
+      .setCentroid({ lat: 12.121212, lon: 21.212121 })
+      .addParent('country', 'Germany', '85633111', 'DEU');
+
+    const expectedDoc = new Document('whosonfirst', 'placetype', '1')
+      .setCentroid({ lat: 12.121212, lon: 21.212121 })
+      .addParent('country', 'Germany', '85633111', 'DEU')
+      .addParent('country', 'Deutschland', '85633111', null); // endonym added
+
+    const resolver = {
+      lookup: (centroid, search_layers, callback) => {
+        const result = {
+          country: [{ id: 85633111, name: 'Germany' }]
+        };
+        setTimeout(callback, 0, null, result);
+      }
+    };
+
+    const lookupStream = stream(resolver, { useEndonyms: true });
+    t.doesNotThrow(() => {
+      test_stream([inputDoc], lookupStream, (err, actual) => {
+        t.deepEqual(actual, [expectedDoc], 'country should have additional endonyms');
+        t.end();
+      });
+    });
+  });
+
+  test.test('endonyms - locality - megacity - Rome/Roma', (t) => {
+    const inputDoc = new Document('whosonfirst', 'placetype', '1')
+      .setCentroid({ lat: 12.121212, lon: 21.212121 })
+      .addParent('locality', 'Rome', '101752607')
+      .addParent('country', 'Italy', '85633253', 'ITA');
+
+    const expectedDoc = new Document('whosonfirst', 'placetype', '1')
+      .setCentroid({ lat: 12.121212, lon: 21.212121 })
+      .addParent('locality', 'Rome', '101752607')
+      .addParent('locality', 'Roma', '101752607') // endonym added
+      .addParent('country', 'Italy', '85633253', 'ITA')
+      .addParent('country', 'Italia', '85633253'); // endonym added
+
+    const resolver = {
+      lookup: (centroid, search_layers, callback) => {
+        const result = {
+          locality: [{ id: 101752607, name: 'Rome' }],
+          country: [{ id: 85633253, name: 'Italy' }],
+        };
+        setTimeout(callback, 0, null, result);
+      }
+    };
+
+    const lookupStream = stream(resolver, { useEndonyms: true });
+    t.doesNotThrow(() => {
+      test_stream([inputDoc], lookupStream, (err, actual) => {
+        t.deepEqual(actual, [expectedDoc], 'locality should have additional endonyms');
+        t.end();
+      });
+    });
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ require ('./schema.js');
 require ('./index.js');
 require ('./lookupStreamTest.js');
 require ('./lookupStreamPostalCityTest.js');
+require ('./lookupStreamEndonymsTest.js');
 require ('./localPipResolverTest.js');
 require ('./remotePipResolverTest.js');
 require ('./pip/index.js');


### PR DESCRIPTION
This PR attempts to resolve a long-standing issue in Pelias where parent properties can only be specified in English (or in the 'default language').

For example querying for a country directly works fine, you can query for `Germany`, `Deutschland` or `Allemagne` to find Germany, the search logic usually targets the 'default language' and the target language of the `User-Agent`.

The issue is when using the country name in support of another query, such as the example [10 Torstraße Germany](https://pelias.github.io/compare/#/v1/autocomplete?text=10+Torstra%C3%9Fe+Germany) which works as expected, but the query [10 Torstraße Deutschland](https://pelias.github.io/compare/#/v1/autocomplete?text=10+Torstra%C3%9Fe+Deutschland) fails.

This is really not ideal since it's very English-centric, in this German example it's particularly odd that the official language of the country isn't supported but English is.

The reason for this dates back to the original schema design back in ~2014, where the parent properties weren't modelled with the idea of multiple languages like the `name.*` fields were, so it's been tricky to fix.

Coupled with that was the design of the PIP service and this repo wof-admin-lookup, the service is designed in such a way that it only ever loads and serves a single name for a place, changing this interface would be a breaking change that I don't have the bandwidth to tackle at the moment.

This PR provides some relief to the situation by providing dictionaries of [Endonyms](https://en.wikipedia.org/wiki/Endonym_and_exonym) for countries and mega cities which will *optionally* be added as aliases to every record *(under a pelias/config flag)*.

It's not clear at this stage what effect adding multiple aliases to half a billion records will have on the size of the index, performance and query quality, so for now I've pared it down to just countries and megacities.

In the future, depending on the success of this PR we can expand to cover Exonyms (likely only a subset of languages), however it may be preferable to reconsider the schema design at that point rather than clump all languages in the same field.

---

how it works:

- the `src/data/aliases/country-language-map.json` file is generated using the provided `sql` file from a WOF bundle
- the file contains a list of countries, their wof ID and a list of their local and spoken languages
- for each placetype we can generate a `src/data/aliases/{placetype}-endonyms.psv` file containing aliases
- when the config flag `imports.adminLookup.useEndonyms` is enabled, the code in this PR is activated
- for each record, modifying only the `parent.*` properties, add any missing aliases based on the parent ID previously assigned