### PR TITLE
endonyms: add endonyms dictionary for region placetype

### DIFF
--- a/src/data/aliases/region-endonyms.psv
+++ b/src/data/aliases/region-endonyms.psv
@@ -1,0 +1,2503 @@
+85632267|Republic of Srpska|Република Српска
+85632275|Lakshadweep|लक्षद्वीप
+85632279|Brcko Distrikt|Brčko distrikt|Distrikt Brčko|Брчко Дистрикт
+85632539|Puntland|أرض البنط
+85667493|Badghis|بادغيس ولايت|ولایت بادغیس
+85667497|Herat|استان هرات|هرات ولايت
+85667503|Bamian|باميان ولايت|ولایت بامیان
+85667505|Balkh|بلخ ولايت|ولایت بلخ
+85667509|Faryab|فارياب ولايت|ولایت فاریاب
+85667513|Jowzjan|جوزجان ولايت|ولایت جوزجان
+85667519|Ghowr|غور ولايت|ولایت غور
+85667523|Sar-e Pol|سرپل ولايت|ولایت سرپل
+85667527|Farah|فراه ولايت|ولایت فراه
+85667531|Helmand|هلمند ولايت|ولایت هلمند
+85667537|Nimruz|نيمروز ولايت|ولایت نیمروز
+85667541|Oruzgan|د ارزگان ولايت|ولایت اروزگان
+85667549|Kandahar|ولایت قندهار|کندهار ولايت
+85667555|Zabol|زابل ولايت|ولایت زابل
+85667561|Ghazni|غزني ولايت|ولایت غزنی
+85667563|Khowst|خوست ولايت|ولایت خوست
+85667567|Paktika|ولایت پکتیکا|پکتيکا ولايت
+85667573|Badakhshan|بدخشان ولايت|ولایت بدخشان
+85667577|Nurestan|نورستان ولايت|ولایت نورستان
+85667581|Kunar|ولایت کنر|کونړ ولايت
+85667585|Konduz|ولایت کندز|کندوز ولايت
+85667591|Nangarhar|د ننګرهار ولايت|ولایت ننگرهار
+85667595|Takhar|تخار ولايت|ولایت تخار
+85667601|Baghlan|بغلان ولايت|ولایت بغلان
+85667603|Kabul|ولایت کابل|کابل ولايت
+85667609|Kapisa|ولایت کاپیسا|کاپيسا ولايت
+85667617|Laghman|لغمان ولايت|ولایت لغمان
+85667623|Lowgar|لوګر ولايت|ولایت لوگر
+85667627|Parwan|ولایت پنجشیر|پنجشېر ولايت
+85667631|Samangan|سمنګان ولايت|ولایت سمنگان
+85667635|Wardak|ميدان وردګ ولايت|ولایت وردک
+85667641|Paktia|ولایت پکتیا|پکتيا ولايت
+85667669|Luanda|Luanda Province
+85667673|Uíge|Uíge Province
+85667687|Bié|Bíe Province
+85667707|Huíla|Huíla Province
+85667783|Durrës|Qarku i Durrësit
+85667789|Fier|Qarku i Fierit
+85667793|Shkoder|Shkodër
+85667797|Kukës|Qarku i Kukësit
+85667801|Qarku i Vlorës|Vlorë
+85667807|Korçë|Qarku i Korçës
+85667811|Berat|Qarku i Beratit
+85667815|Elbasan|Qarku i Elbasanit
+85667819|Gjirokaste|Gjirokastë
+85667821|Dibër|Qarku i Dibrës
+85667829|Lezhë|Qarku i Lezhës
+85667923|Andorra la Vella|Parròquia d'Andorra la Vella
+85667925|La Massana|Massana
+85667951|Ras al Khaimah|رأس الخيمة
+85667955|Umm Al Quwain|أم القيوين
+85667959|Fujairah|الفجيرة
+85667963|Neutral Zone|المنطقة المحايدة
+85667969|Ajman|عجمان
+85667973|Neutral Zone|المنطقة المحايدة
+85667977|Sharjah|الشارقة
+85667981|Abu Dhabi|أبو ظبي
+85667983|Dubai|دبي
+85667997|San Juan|San Juan Province
+85668011|Neuquen|Neuquén
+85668025|Rio Negro|Río Negro
+85668031|Cordoba|Córdoba
+85668059|Tucuman|Tucumán
+85668073|Entre Rios|Entre Ríos
+85668077|Santa Fe|Santa Fe Province
+85668081|Autonomous City of Buenos Aires|Ciudad de Buenos Aires
+85668083|Aragatsotn|Aragatsotni Marz
+85668085|Armavir|Արմավիրի մարզ
+85668089|Shirak|Շիրակի մարզ
+85668095|Tavush|Տավուշի մարզ
+85668099|Ararat|Արարատի մարզ
+85668103|Geghark'unik'|Գեղարքունիքի մարզ
+85668105|Kotayk'|Կոտայք
+85668109|Lorri|Լոռու մարզ
+85668115|Erevan|Քաղաք Երէվան
+85668119|Syunik'|Սյունիքի մարզ
+85668123|Vayots' Dzor|Վայոց Ձորի մարզ
+85668195|Agstafa|Ağstafa
+85668199|Daskasan|Daşkəsən
+85668205|Gadabay|Gədəbəy
+85668211|Xanlar|Xanlar Rayonu
+85668221|Kalbacar|Kəlbəcər
+85668233|Samkir|Şəmkir
+85668249|Baki|Bakı
+85668251|Abseron|Abşeron
+85668257|Agdam|Ağdam Rayonu
+85668259|Agdas|Ağdaş
+85668289|Agsu|Ağsu
+85668303|Barda|Bərdə Rayonu
+85668317|Bilasuvar|Biləsuvar
+85668323|Cabrayil|Cəbrayıl
+85668331|Calilabad|Cəlilabad
+85668339|Davaci|Şabran
+85668351|Fuzuli|Füzuli Rayonu
+85668357|Goycay|Göyçay
+85668365|Imisli|İmişli
+85668373|Ismayilli|İsmayıllı
+85668383|Kurdamir|Kürdəmir
+85668389|Lankaran|Lənkəran
+85668397|Masalli|Masallı
+85668409|Neftcala|Neftçala
+85668425|Siyazan|Siyəzən
+85668433|Saatli|Saatlı
+85668449|Salyan|Salyan rayonu
+85668465|Sumqayit|Sumqayıt
+85668497|Yardimli|Yardımlı
+85668519|Agcabadi|Ağcabədi
+85668531|Balakan|Balakən
+85668549|Oguz|Oğuz
+85668591|Xacmaz|Xaçmaz
+85668611|Xocavand|Xocavənd Rayonu
+85668621|Lankaran|Laçın Rayonu
+85668643|Susa|Şuşa rayonu
+85668657|Xankəndi Şəhəri|Xocali
+85668659|Zangilan|Zəngilan
+85668663|Azarbayjan-e Gharbi|Sədərək
+85668665|Ordubad|Ordubad Rayonu
+85668667|Sarur|Şərur
+85668673|Babek|Babək
+85668681|Naxcivan|Naxçıvan Muxtar Respublikası
+85668683|Shakhbuz|Şahbuz
+85668691|Xankandi|Xocalı Rayonu
+85668693|Goranboy|Goranboy Rayonu
+85668697|Lankaran|Lənkəran
+85668711|Susa|Şuşa Şəhəri
+85668717|Kəngərli|Sarur
+85668725|Cankuzo|Cankuzo Province|iProvense ya Cankuzo
+85668727|Karuzi|Karuzi Province|iProvense ya Karuzi
+85668731|Rutana|Rutana Province|iProvense ya Rutana
+85668735|Ruyigi|Ruyigi Province|iProvense ya Ruyigi
+85668739|Bubanza|Bubanza Province|iProvense ya Bubanza
+85668745|Bururi|Bururi Province|iProvense ya Bururi
+85668749|Cibitoke|Cibitoke Province|iProvense ya Cibitoke
+85668753|Gitega|Gitega Province|iProvense ya Gitega
+85668757|Kayanza|Kayanza Province|iProvense ya Kayanza
+85668763|Makamba|Makamba Province|iProvense ya Makamba
+85668781|Ngozi|Ngozi Province|iProvense ya Ngozi
+85668783|Kirundo|Kirundo Province|iProvense ya Kirundo
+85668787|Muyinga|Muyinga Province|iProvense ya Muyinga
+85668791|Bujumbura Mairie|Bujumbura Mairie Province|IProvense ya Bujumbura Mairie
+85668797|Muramvya|Muramvya Province|iProvense ya Muramvya
+85668799|Bujumbura Rural|IProvense ya Bujumbura Rural
+85668803|Borgou|Borgou Department
+85668805|Alibori|Alibori Department
+85668807|Collines|Collines Department
+85668809|Atlantique|Atlantique Department
+85668811|Littoral|Littoral Department
+85668815|Kouffo|Kouffo Department
+85668817|Ouémé|Ouémé Department
+85668819|Zou|Zou Department
+85668821|Plateau|Plateau Department
+85668823|Mono|Mono Department
+85668825|Atakora|Atakora Department
+85668827|Donga|Donga Department
+85668851|Mou Houn|Mouhoun
+85668869|BAM|Bam
+85668951|Nahouri|Naouri
+85669007|Noumbiel|Poni
+85669009|Dhaka|ঢাকা
+85669015|Khulna|খুলনা
+85669019|Barisal|বরিশাল
+85669023|Chittagong|চট্টগ্রাম
+85669025|Sylhet|সিলেট
+85669031|Rajshahi|রাজশাহী
+85669035|Rajshahi|রংপুর
+85669039|Southern|الجنوبية
+85669043|Northern|الشمالية
+85669049|Middle|الوسطى
+85669053|Capital|المنامة
+85669059|Muharraq|المحرق
+85669203|Kanton br. 10|West Bosnia|Županija 10|Кантон 10
+85669207|Una-Sana|Unsko-sanska županija|Unsko-sanski kanton|Унско-Сански Кантон
+85669213|Central Bosnia|Srednjobosanski kanton|Županija Središnja Bosna|Средњобосански кантон
+85669217|West Herzegovina|Zapadnohercegovački kanton|Županija Zapadnohercegovačka|Западнохерцеговачки кантон
+85669221|Hercegovačko-neretvanska županija|Hercegovačko-neretvanski kanton|Herzegovina-Neretva|Херцеговачко-неретвански кантон
+85669225|Tuzla|Tuzlanska županija|Tuzlanski kanton|Тузлански кантон
+85669231|Zenica-Doboj|Zeničko-dobojska županija|Zeničko-dobojski kanton|Зеничко-добојски кантон
+85669235|Sarajevo|Sarajevo kanton|Sarajevska županija|Кантон Сарајево
+85669239|Bosansko-Podrinjska Županija Goražde|Bosansko-podrinjski kanton Goražde|Bosnian Podrinje|Босанско-Подрињски Кантон Горажде
+85669243|Posavina|Posavski kanton|Županija Posavska|Посавски кантон
+85669249|Doboj|Добој
+85669253|Banja Luka|Бања Лука
+85669261|Bijeljina|Бијељина
+85669267|Vlasenica|Власеница
+85669271|Sarajevo-romanija|Stanislav Galić
+85669279|Trebinje|Требиње
+85669287|Brestskaya Voblasts'|Брестская область|Брэстская Вобластсь
+85669291|Homyel'skaya Voblasts'|Гомельская Вобластсь|Гомельская область
+85669295|Mahilyowskaya Voblasts'|Магілёўская Вобласць|Могилёвская область
+85669301|Vitsyebskaya Voblasts'|Витебская область|Віцебская Вобласць
+85669305|Haradzyenskaya Voblasts'|Гродзенская Вобласць|Гродненская область
+85669309|Minskaya Voblasts'|Минская область|Мінская Вобласць
+85669313|Minsk|Минск|Мінск
+85669395|Cochabamba|Quchapampa jach'a suyu|Quchapampa suyu
+85669399|Chuqichaka suyu|Chuqisaka jach'a suyu|Chuquisaca
+85669403|Beni suyu|El Beni|Wini jach'a suyu
+85669409|Chuqiyapu jach'a suyu|Chuqiyapu suyu|La Paz
+85669413|Oruro|Uru Uru suyu|Ururu jach'a suyu
+85669417|Pando|Pando suyu|Pandu jach'a suyu
+85669421|P'utuqsi suyu|Potosí|Putusi jach'a suyu
+85669427|Santa Cruz|Santa Krus jach'a suyu|Santa Krus suyu
+85669431|Tarija|Tarija suyu|Tarixa jach'a suyu
+85669501|Chhukha|ཆུ་ཁ་རྫོང་ཁག་
+85669505|Daga|དར་དཀར་ན་རྫོང་ཁག་
+85669509|Ha|ཧཱ་རྫོང་ཁག་
+85669513|Paro|སྤ་རོ་རྫོང་ཁག་
+85669521|Gasa|མགར་ས་རྫོང་ཁག་
+85669523|Samchi|བསམ་རྩེ་རྫོང་ཁག
+85669527|Thimphu|ཐིམ་ཕུ་རྫོང་ཁག
+85669531|Punakha|སྤུ་ན་ཁ་རྫོང་ཁག
+85669537|Bumthang|བུམ་ཐང་རྫོང་ཁག་
+85669541|Chirang|རྩི་རང་རྫོང་ཁག
+85669545|Geylegphug|གསར་སྤང་རྫོང་ཁག
+85669549|Lhuntshi|ལྷུན་རྩེ་རྫོང་ཁག་
+85669559|Shemgang|གཞལམ་སྒང་རྫོང་ཁག
+85669563|Tongsa|ཀྲོང་གསར་རྫོང་ཁག
+85669571|Mongar|མོང་སྒར་རྫོང་ཁག་
+85669575|Pemagatsel|པད་མ་དགའ་ཚལ་རྫོང་ཁག་
+85669579|Samdrup|བསམ་གྲུབ་ལྗོངས་མཁར་རྫོང་ཁག
+85669583|Tashigang|བཀྲིས་སྒང་རྫོང་ཁག
+85669589|Ghanzi|Kgaolo ya Ghanzi
+85669593|Kgalagadi|Kgalagadi le dikgaolo tse di mabapi
+85669601|Central|Kgaolo ya Legare
+85669619|Motsana wa Molapowabojang|Southern
+85669639|Lobatse|South-East
+85669645|Central|Kgaolo ya Legare
+85669649|Central|Kgaolo ya Legare
+85669653|Motsana wa Molapowabojang|Southern
+85669655|Bangui|Bangui Prefecture|Kötä gbätä tî Bangî
+85669661|Ombella-M'Poko|Sêse tî kömändâ-kötä tî Ömbëlä-Pökö
+85669665|Basse-Kotto|Sêse tî kömändâ-kötä tî Do-Kötö
+85669667|Lobaye|Sêse tî kömändâ-kötä tî Lobâye
+85669671|Mambéré-Kadéï|Mambéré-Kadéï Prefecture|Sêse tî kömändâ-kötä tî Mambere-Kadei
+85669675|Sangha-Mbaéré|Sangha-Mbaéré Prefecture|Sêse tî kömändâ-kötä tî Sangä-Mbaere
+85669681|Nana-Mambéré|Nana-Mambéré Prefecture|Sêse tî kömändâ-kötä tî Nanä-Mambere
+85669685|Ouham-Pendé|Ouham-Pendé Prefecture|Sêse tî kömändâ-kötä tî Wâmo-Pendë
+85669689|Bamingui-Bangoran|Sêse tî kömändâ-kötä tî Bamïngï-Bangoran
+85669693|Nana-Grébizi|Nana-Grébizi Prefecture|Sêse tî kömändâ-kötä tî Nanä-Gïrïbïzï
+85669697|Kémo|Kémo Prefecture|Sêse tî kömändâ-kötä tî Kemö
+85669699|Ouaka|Sêse tî kömändâ-kötä tî Wäkä
+85669701|Ouham|Sêse tî kömändâ-kötä tî Wâmo
+85669703|Sêse tî kömändâ-kötä tî Vakaga|Vakaga
+85669705|Haute-Kotto|Sêse tî kömändâ-kötä tî Tö-Kötö
+85669707|Haut-Mbomou|Sêse tî kömändâ-kötä tî Tö-Mbömü
+85669709|Mbomou|Sêse tî kömändâ-kötä tî Mbömü
+85669879|Fromager|Gôh
+85669921|Moyen-Comoe|Moyen-Comoé
+85669933|Extreme-Nord|Far North Region
+85669937|Littoral|Littoral Province
+85669941|Nord-Ouest|North-West Province
+85669945|Centre|Centre Region
+85669949|East Province|Est
+85669953|Adamaoua|Adamaoua Province
+85669957|Nord|North Province
+85669961|Ouest|West Region
+85669967|South-West Province|Sud-Ouest
+85669971|South Province|Sud
+85669975|Équateur|Équateur Province
+85669979|Eastern Province|Orientale
+85669985|Bandundu|Bandundu Province
+85669989|Kasaï-Occidental|Kasaï-Occidental Province
+85669993|Bas-Congo|Bas-Congo Province
+85669997|Kinshasa|Kinshasa City
+85670003|South Kivu|Sud-Kivu
+85670011|Kasaï oriental|Kasaï-Occidental Province
+85670021|Nord-Kivu|North Kivu
+85670023|Cuvette-Ouest|Cuvette-Ouest Department
+85670027|Bouenza|Bouenza Department
+85670035|Sangha|Sangha Department
+85670041|Pool|Pool Department
+85670045|Cuvette|Cuvette Department
+85670053|Lékoumou|Lékoumou Department
+85670059|Niari|Niari Region
+85670063|Plateaux|Plateaux Department
+85670067|Brazzavile Department|Brazzaville
+85670071|Kouilou Department|Pointe Noire
+85670133|Boyaca|Boyacá
+85670137|Cordoba|Córdoba
+85670151|San Andres y Providencia|San Andrés y Providencia
+85670165|Bogota D.C.|Distrito Especial
+85670169|Quindio|Quindío
+85670179|Caqueta|Caquetá
+85670193|Narino|Nariño
+85670207|Atlantico|Atlántico
+85670209|Bolivar|Bolívar
+85670219|Choco|Chocó
+85670245|Guavaire|Guaviare
+85670249|Guainia|Guainía
+85670259|Vaupes|Vaupés
+85670267|Mohéli|موهيلي
+85670273|Grande Comore|غراند كومور
+85670277|Anjouan|أنجوان
+85670283|São Filipe|São Filipe Municipality
+85670305|São Miguel|São Miguel Municipality
+85670315|São Salvador do Mundo|São Salvador do Mundo Municipality
+85670321|São Domingos|São Domingos Municipality
+85670351|Tarrafal de São Nicolau|Tarrafal de São Nicolau Municipality
+85670355|São Vicente|São Vicente Municipality
+85670465|Curacao|Curaçao|Pais Kòrsou
+85670467|Ali Sabieh|على صابح
+85670473|Djibouti|جيبوتي
+85670477|Arta|عرتا
+85670483|Dikhil|دخيل
+85670485|Obock|أوبوك
+85670491|Tadjourah|تاجورة
+85670543|Santiago Rodriguez|Santiago Rodríguez
+85670557|Sánchez Ramirez|Sánchez Ramírez
+85670563|San Pedro de Macorís|San Pedro de Marcoris
+85670567|Monte Cristi|Monte Cristri
+85670575|Dajabon|Dajabón
+85670583|Hermanas|Salcedo
+85670601|Elias Piña|La Estrelleta
+85670627|San Jose de Ocoa|San José de Ocoa
+85670645|Maria Trinidad Sanchéz|María Trinidad Sánchez
+85670653|Samana|Samaná
+85670655|San Cristobal|San Cristóbal
+85670663|El Seibo|El Seybo
+85670673|La Romana|Romana
+85670677|Adrar|أدرار
+85670683|Aïn Témouchent|wilaya d'Aïn Témouchent|عين تموشنت
+85670689| وهران|Oran|wilaya d'Oran
+85670691|Sidi Bel Abbes|wilaya de Sidi Bel Abbès|سيدي بلعباس
+85670695|Tlemcen|تلمسان
+85670699|Béchar|wilaya de Béchar|بشار
+85670707|Naama|Naâma|النعامة
+85670709|Tindouf|تندوف
+85670713|Annaba|عنابة
+85670719| الطارف|El Tarf
+85670723|Jijel|جيجل
+85670727|Skikda|wilaya de Skikda|سكيكدة
+85670731|Illizi|إليزي
+85670735|Tamanghasset|wilaya de Tamanrasset|تامنراست
+85670741|El Bayadh|البيض
+85670745|El Oued|الوادي
+85670749|Ghardaia|wilaya de Ghardaïa|غرداية
+85670753|Laghouat|الأغواط
+85670759|Ouargla|ورقلة
+85670761|Alger|الجزائر
+85670765|Boumerdes|Wilaya de Boumerdès|بومرداس
+85670767|Tizi Ouzou|تيزي وزو
+85670771|Tipaza|wilaya de Tipaza|تيبازة
+85670777|Aïn Defla|wilaya de Aïn Defla|عين الدفلى
+85670781|Chlef|الشلف
+85670785|Mascara|معسكر
+85670787|Mostaganem|مستغانم
+85670791|Relizane|غليزان
+85670797|Saida|wilaya de Saïda|سعيدة‎
+85670801|Tiaret|تيارت
+85670805|Tissemsilt|تسمسيلت
+85670809|Bordj Bou Arréridj|wilaya de Bordj Bou Arreridj|برج بوعريريج‎
+85670815|Béjaia|wilaya de Béjaïa|بِجَايَة‎
+85670819|Blida|البليدة
+85670823|Bouira|البويرة
+85670827|Biskra|wilaya de Biskra|بسكرة
+85670833|Djelfa|الجلفة
+85670837|Medea|Wilaya de Médéa|المدية
+85670841|M'Sila|M'sila|المسيلة
+85670845|Sétif|wilaya de Sétif|سطيف
+85670851|Batna|باتنة
+85670855|Constantine|قسنطينة
+85670857|Guelma|قالمة
+85670861|Khenchela|خنشلة
+85670867|Mila|ميلة
+85670871|Oum el Bouaghi|wilaya d'Oum El Bouaghi|أم البواقي
+85670875|Souk Ahras|سوق أهراس
+85670879|Tébessa|wilaya de Tébessa|تبسة
+85670885|Asway marka|Azuay
+85670887|El Oro|Kuri marka
+85670891|Loja|Loja marka
+85670895|Zamora Chinchipe|Zamora Chinchipi marka|Zamora-Chinchipe
+85670899|Galapagos|Galápagos
+85670905|Bolivar|Bolívar marka
+85670909|Canar|Cañar|Kañar marka
+85670915|Cotopaxi|Kutupaksi marka
+85670917|Guayas|Wayas marka
+85670923|Los Rios|Mayukuna marka
+85670927|Manabi|Manawi marka
+85670931|Chimborazo|Chimpurasu marka
+85670935|Morona Santiago|Morona Santiago marka|Morona-Santiago
+85670941|Orellana|Orellana marka
+85670945|Pichincha|Pichincha marka
+85670949|Pastasa marka|Pastaza
+85670953|Napo|Tungurahua|Tunkurawa marka
+85670959|Napo|Napu Marka|Tungurahua
+85670963|Esmeraldas|culonas
+85670967|Carchi|Karchi marka
+85670971|Imbabura|Impapura marka
+85670977|Sucumbios|Sukumpiyu marka
+85670979|Santa Elena|Santa Elena marka
+85670983|Santo Domingo de los Tsáchilas|Tsachila marka
+85670985|Gharbia|الغربية
+85670989|El Ismailia|الإسماعيلية
+85670995|Menofia|المنوفية
+85670999|Cairo|القاهرة
+85671003|Qalubia|القليوبية
+85671007|Sharqia|الشرقية
+85671013|El Suez|السويس
+85671017|Daqahlia|الدقهلية
+85671021|Port Said|بورسعيد
+85671025|Dumiat|دمياط
+85671031|Matrouh|مطروح
+85671035|Beheira|البحيرة
+85671037|Fayoum|الفيوم
+85671041|Alexandria|الإسكندرية
+85671047|Giza|الجيزة
+85671049|Menia|المنيا
+85671053|Bani Sueif|بني سويف
+85671057|Kafr El Sheikh|كفر الشيخ
+85671061|Aswan|أسوان
+85671069|Asyout|أسيوط
+85671071|El Wadi El Gedeed|الوادي الجديد
+85671075|Qena|قنا
+85671079|Sohag|سوهاج
+85671085|El Bahr El Ahmar|البحر الاحمر
+85671089|South Sinai|جنوب سيناء
+85671093|North Sinai|شمال سيناء
+85671097|Luxor|الأقصر
+85671101|Gash-Barka|Zoba Gash-Barka|غاش-باركا
+85671105|Semien-Keih-Bahri|شمال البحر الأحمر|ዞባ ሰሜናዊ ቀይሕ ባሕሪ
+85671109|Debub|منطقة الجنوب|ዞባ ደቡብ
+85671111|Debub-Keih-Bahri|البحر الأحمر الجنوبي|ዞባ ደቡባዊ ቀይሕ ባሕሪ
+85671121|Amhara|Āmara Kilil
+85671125|Tigray|Tigray Kilil
+85671129|Afar|Āfar Kilil
+85671133|Southern Nations Nationalities and People's Region|ደቡብ ብሔሮች ብሔረሰቦችና ሕዝቦች ክልል
+85671137|Gambela|Gambēla Hizboch Kilil
+85671141|Oromia|Oromīya Kilil
+85671147|Benshangul-Gumaz|ቤንሻንጉል ጉሙዝ ክልል
+85671149|Addis Ababa|Ādīs Ābeba Āstedader
+85671155|Somali|Sumalē Kilil
+85671159|Dire Dawa|Dirē Dawa Āstedader
+85671163|Harari|ሐረሪ ሕዝብ ክልል
+85671167|Central|Central Division
+85671173|Eastern|Eastern Division
+85671179|Northern|Northern Division
+85671181|Western|Western Division
+85671195|French Guiana|Guyane
+85671199|La Réunion|Reunion
+85671235|Estuaire|Estuaire Province
+85671237|Ogooué-Ivindo|Ogooué-Ivindo Province
+85671241|Woleu-Ntem|Woleu-Ntem Province
+85671247|Moyen-Ogooué|Moyen-Ogooué Province
+85671249|Ngouni Province|Ngounié
+85671251|Nyanga|Nyanga Province
+85671255|Ogooué-Maritime|Ogooué-Maritime Province
+85671257|Haut-Ogooue|Haut-Ogooué Province
+85671265|Ogooué-Lol Province|Ogooué-Lolo
+85671267|Abkhazia|აფხაზეთი
+85671273|Ajaria|აჭარის ავტონომიური რესპუბლიკა
+85671275|Ozurget´is Raioni|გურიის მხარე
+85671281|Khonis Raioni|სამეგრელო-ზემო სვანეთის მხარე
+85671285|Vanis Raioni|იმერეთის მხარე
+85671287|Gurjaanis Raioni|კახეთის მხარე
+85671291|Dushet´is Raioni|მცხეთა-მთიანეთის მხარე
+85671295|Ambrolauris Raioni|რაჭა-ლეჩხუმისა და ქვემო სვანეთის მხარე
+85671301|T´bilisi|თბილისი
+85671305|T´et´ritsqaros Raioni|ქვემო ქართლის მხარე
+85671309|Akhalts´ikhis Raioni|სამცხე-ჯავახეთის მხარე
+85671313|Goris Raioni|შიდა ქართლის მხარე
+85671379|Coyah|Kindia
+85671385|Dalaba|Mamou
+85671393|Dinguiraye|Faranah
+85671395|Dubréka|Kindia
+85671403|Forécariah|Kindia
+85671409|Boké|Fria
+85671425|Kérouane|Kérouané
+85671485|Mamou|Pita
+85671497|Labé|Tougué
+85671503|Kindia|Télimélé
+85671559|Gabu|Gabú
+85671563|Annobon|Annobón Province|Province d'Annobón
+85671565|Centro Sur|Centro-Sur
+85671583|Kie-Ntem|Kié-Ntem|Kié-Ntem Province
+85671591|Wele-Nzas|Wele-Nzas Province
+85671595|Bioko Norte|Bioko-Norte
+85671599|Bioko Sur|Bioko-Sur
+85671647|Peten|Petén
+85671651|Quetzaltenango|Quezaltenango
+85671683|Suchitepeque|Suchitepequez
+85671687|Sacatepequez|Sacatepéquez
+85671695|Solola|Sololá
+85671697|Totonicapan|Totonicapán
+85671733|Quiche|Quiché
+85671775|Central and Western|中西區
+85671779|Wan Chai|灣仔
+85671785|Eastern|東區
+85671789|Southern|南區
+85671791|Yau Tsim Mong|油尖旺區
+85671797|Kowloon City|九龍城
+85671799|Sham Shui Po|深水埗
+85671805|Wong Tai Sin|黄初平
+85671809|Kwun Tong|觀塘區
+85671813|Sai Kung|西貢區
+85671817|Sha Tin|沙田
+85671823|Kwai Tsing|葵青區
+85671827|Tsuen Wan|荃灣區
+85671831|Tuen Mun|屯門區
+85671833|Yuen Long|元朗區
+85671839|North|北區
+85671843|Tai Po|大埔區
+85671847|Islands|離島區
+85671933|Grand' Anse|Grand'Anse|Grandans
+85671937|Nip|Nippes
+85671941|Depatman Nòdwès|Nord-Ouest
+85671947|Depatman Sid|Sud
+85671949|Artibonite|L'Artibonite|Latibonit
+85671955|Centre|Depatman Sant
+85671957|Nord-Est|Nòdès
+85671961|Depatman Nò|Nord
+85671967|Lwès|Ouest
+85671969|Depatman Sidès|Sud-Est
+85671977|East Kalimantan|Kalimantan Timur
+85671983|Jawa Barat|West Java
+85671987|Central Java|Jawa Tengah
+85672005|Kalimantan Barat|West Kalimantan
+85672013|South Sumatra|Sumatra Selatan
+85672019|Bangka Belitung Islands|Kepulauan Bangka Belitung
+85672027|East Java|Jawa Timur
+85672031|Kalimantan Selatan|South Kalimantan
+85672037|East Nusa Tenggara|Nusa Tenggara Timur
+85672041|South Sulawesi|Sulawesi Selatan
+85672045|Sulawesi Barat|West Sulawesi
+85672049|Kepulauan Riau|Riau Islands
+85672063|Central Kalimantan|Kalimantan Tengah
+85672067|Papua Barat|West Papua
+85672073|North Sumatra|Sumatra Utara
+85672081|North Sulawesi|Sulawesi Utara
+85672085|Maluku Utara|North Maluku
+85672087|Sumatra Barat|West Sumatra
+85672103|Nusa Tenggara Barat|West Nusa Tenggara
+85672105|Southeast Sulawesi|Sulawesi Tenggara
+85672111|Central Sulawesi|Sulawesi Tengah
+85672119|Chandigarh|चंडीगढ़
+85672123|Delhi|दिल्ली
+85672129|Himachal Pradesh|हिमाचल प्रदेश
+85672133|Haryana|हरियाणा
+85672137|Jammu and Kashmir|جموں و کشمیر
+85672141|Andhra Pradesh|आंध्र प्रदेश
+85672149|Kerala|केरल
+85672157|Odisha|ओडिशा
+85672163|Dadra and Nagar Haveli|दादरा और नगर हवेली
+85672165|Karnataka|कर्नाटक
+85672171|Maharashtra|महाराष्ट्र
+85672175|Andaman and Nicobar Islands|अंडमान और निकोबार द्वीपसमूह
+85672181|Assam|असम
+85672183|Manipur|मणिपुर
+85672187|Nagaland|नागालैंड
+85672193|Meghalaya|मेघालय
+85672195|Punjab|पंजाब
+85672201|Rajasthan|राजस्थान
+85672205|Uttar Pradesh|उत्तर प्रदेश
+85672209|Uttarakhand|उत्तराखंड
+85672213|Jharkhand|झारखंड
+85672219|West Bengal|पश्चिम बंगाल
+85672225|Bihar|बिहार
+85672229|Sikkim|सिक्किम
+85672231|Chhattisgarh|छत्तीसगढ़
+85672239|Madhya Pradesh|मध्य प्रदेश
+85672241|Puducherry|पुदुचेरी
+85672245|Tamil Nadu|तमिलनाडु
+85672249|Gujarat|गुजरात
+85672255|Goa|गोवा
+85672259|Arunachal Pradesh|अरुणाचल प्रदेश
+85672263|Mizoram|मिज़ोरम
+85672267|Tripura|त्रिपुरा
+85672271|Daman and Diu|दमन और दीव
+85672283|Kohgiluyeh va Buyer Ahmad|استان کهگیلویه و بویراحمد
+85672289|Bushehr|استان بوشهر
+85672291|Esfahan|اصفهان
+85672295|Fars|فارس
+85672299|Golestan|اُستانِ گُلِستان
+85672303|Mazandaran|اُستانِ مازَندَران
+85672309|Semnan|اُستانِ سِمنان
+85672313|Tehran|اُستانِ تِهران
+85672317|Yazd|اُستانِ يَزد
+85672319|Chahar Mahall va Bakhtiari|استان چهارمحال و بختیاری
+85672325|Khuzestan|استان خوزستان
+85672329|Lorestan|استان لرستان
+85672333|Ilam|اُستانِ ايلام
+85672337|Hormozgan|استان هرمزگان
+85672343|Ardabil|استان اردبيل
+85672347|Markazi|اُستانِ مَركَزی
+85672351|Qom|اُستانِ قُم
+85672355|Hamadan|اُستانِ هَمَدان
+85672361|Zanjan|اُستانِ زَنجان
+85672367|Qazvin|اُستانِ قَزوين
+85672369|Azarbayjan-e Gharbi|اُستانِ چاهارُم
+85672373|Azarbayjan-e Sharqi|آذربایجان شرقی
+85672379|Kermanshah|Kermānshāh
+85672383|Gilan|Gīlān
+85672387|Kordestan|اُستانِ كُردِستان
+85672391|South Khorasan|استان خراسان جنوبی
+85672397|Khorasan|استان خراسان رضوی
+85672401|Razavi Khorasan|استان خراسان شمالی
+85672405|Sistan va Baluchestan|استان سیستان و بلوچستان
+85672409|Kerman|کرمان
+85672415|Alborz|Ostān-e Alborz
+85672417|Dihok|دهوك
+85672421|At Ta'mim|At-Ta'mim
+85672425|Arbil|أربيل
+85672429|Ninawa|نينوى
+85672435|Sala ad-Din|صلاح الدين
+85672439|An-Najaf|النجف
+85672443|Karbala'|كربلاء
+85672447|Baghdad|بغداد
+85672453|Al-Basrah|البصرة
+85672455|Al-Muthannia|المثنى
+85672459|Al-Qadisiyah|القادسية
+85672463|Dhi-Qar|ذي قار
+85672469|Maysan|ميسان
+85672473|Wasit|واسط
+85672475|As-Sulaymaniyah|السُليمانية
+85672481|Diyala|ديالى
+85672483|Al-Anbar|الأنبار
+85672491|Babil|بابل
+85672493|Capital Region|Höfuðborgarsvæðið
+85672497|Vestfirðir|Westfjords
+85672507|Northwest|Norðurland Vestra
+85672511|Northeast|Norðurland Eystra
+85672515|Southern Peninsula|Suðurnes
+85672519|South|Suðurland
+85672525|Capital Region|Höfuðborgarsvæði
+85672531|Southern|מחוז הדרום‎|لواء الجنوب‎
+85672535|Haifa|מחוז חיפה‬|حيفا‎
+85672541|Central|מְחוֹז הַמֶּרְכָּז‬|المنطقة المركزية
+85672545|Northern|מחוז הצפון‬|منطقة الشمال‎
+85672549|Tel Aviv|תֵּל אָבִיב‬|تل أَبيب‎
+85672551|Jerusalem|ירושלים|القُدس‎
+85672619|Al Aqaba|العقبة
+85672623|Al Mafraq|المفرق
+85672627|Amman|عمان
+85672633|Al Tafilah|الطفيلة
+85672637|Maan|معان
+85672641|Irbid|إربد
+85672643|Ajloun|عجلون
+85672649|Jerash|جرش
+85672653|Al Balqa|البلقاء
+85672659|Madaba|مادبا
+85672661|Al Karak|الكرك
+85672667|Al Zarqa|الزرقاء
+85672671|Hiroshima Prefecture|広島
+85672675|Okayama Prefecture|岡山
+85672679|Shimane Prefecture|島根
+85672685|Tottori Prefecture|鳥取
+85672689|Yamaguchi Prefecture|山口
+85672695|Saga Prefecture|佐賀
+85672697|Fukuoka Prefecture|福岡
+85672703|Kumamoto Prefecture|熊本
+85672707|Miyazaki Prefecture|宮崎
+85672711|Ehime Prefecture|愛媛
+85672715|Kagawa Prefecture|香川
+85672717|Kochi Prefecture|高知
+85672723|Oita Prefecture|大分
+85672729|Tokushima Prefecture|徳島
+85672731|Aichi Prefecture|愛知
+85672735|Gifu Prefecture|岐阜
+85672741|Ishikawa Prefecture|石川
+85672745|Mie Prefecture|三重
+85672749|Nagano Prefecture|長野
+85672753|Shizuoka Prefecture|静岡
+85672759|Toyama Prefecture|富山
+85672761|Hokkaido Prefecture|北海
+85672767|Fukui Prefecture|福井
+85672769|Hyogo Prefecture|兵庫
+85672777|Kyoto Prefecture|京都
+85672779|Nara Prefecture|奈良
+85672785|Osaka Prefecture|大阪
+85672789|Shiga Prefecture|滋賀
+85672795|Wakayama Prefecture|和歌山
+85672797|Chiba Prefecture|千葉
+85672801|Ibaraki Prefecture|茨城
+85672805|Kanagawa Prefecture|神奈川
+85672807|Saitama Prefecture|埼玉
+85672813|Tochigi Prefecture|栃木
+85672817|Tokyo|東京
+85672821|Yamanashi Prefecture|山梨
+85672825|Akita Prefecture|秋田
+85672831|Aomori Prefecture|青森
+85672835|Fukushima Prefecture|福島
+85672839|Iwate Prefecture|岩手
+85672843|Miyagi Prefecture|宮城
+85672849|Niigata Prefecture|新潟
+85672853|Yamagata Prefecture|山形
+85672857|Nagasaki Prefecture|長崎
+85672861|Kagoshima Prefecture|鹿児島
+85672867|Okinawa Prefecture|沖縄
+85672871|Gunma Prefecture|群馬
+85672877|Aqtobe|Aqtöbe Oblysy|Актюбинская область
+85672879|Qostanay|Qostanay Oblysy|Костанайская область
+85672885|Qyzylorda|Qyzylorda Oblysy|Кызылординская область
+85672889|Atyrau|Atyraū Oblysy|Атырауская область
+85672893|Batys Qazaqstan|Батыс Қазақстан облысы|Западно-Казахстанская область
+85672897|Aqmola|Aqmola Oblysy|Акмолинская область
+85672905|Qaraghandy|Qaraghandy Oblysy|Карагандинская область
+85672907|Soltustik Qazaqstan|Северо-Казахстанская область|Солтүстік Қазақстан облысы
+85672911|Pavlodar|Pavlodar Oblysy|Павлодарская область
+85672915|Shyghys Qazaqstan|Восточно-Казахстанская область|Шығыс Қазақстан облысы
+85672921|Almaty|Алматинская область|Алматы облысы
+85672923|Mangghystau|Mangghystaū Oblysy|Мангистауская область
+85672927|Ongtustik Qazaqstan|Оңтүстік Қазақстан облысы|Южно-Казахстанская область
+85672931|Zhambyl|Zhambyl Oblysy|Жамбылская область
+85672937|Almaty|Almaty Oblysy|Алматинская Область
+85672941|Astana|Astana Qalasy|Нур-Султан
+85672943|Coast|Pwani
+85672975|Bishkek|Бишкек
+85672981|Chuy|Chüy Oblasty|Чуйская Область
+85672983|Ysyk-Kol|Ysyk-Köl Oblasty|Иссык-Кульская область
+85672987|Naryn|Naryn Oblasty|Нарынская Область
+85672995|Batken|Batken Oblasty|Баткенская Область
+85672997|Jalal-Abad|Jalal-Abad Oblasty|Джалал-Абадская область
+85673003|Talas|Talas Oblasty|Таласская Область
+85673005|Osh|Ош Облусу|Ошская Область
+85673011|Banteay Mean Cheay|ខេត្តបន្ទាយមានជ័យ
+85673015|Batdambang|ខេត្តបាត់ដំបង
+85673019|Kaoh Kong|ខេត្តកោះកុង
+85673023|Pouthisat|ខេត្តពោធិ៍សាត់
+85673029|Siem Reap Province|ខេត្តសៀមរាប
+85673033|Otdar Mean Cheay|ខេត្តឧត្ដរមានជ័យ
+85673037|Khétt Pailĭn|Pailin
+85673041|Kampong Cham|ខេត្តកំពង់ចាម
+85673047|Kampong Chhnang|ខេត្តកំពង់ឆ្នាំង
+85673051|Kandal|ខេត្តកណ្ដាល
+85673053|Kampong Spoe|ខេត្តកំពង់ស្ពឺ
+85673057|Kampong Thum|ខេត្តកំពង់ធំ
+85673063|Phnum Penh|ភ្នំពេញ
+85673067|Prey Veng|ខេត្តព្រៃវែង
+85673071|Preah Vihear|ខេត្តព្រះវិហារ
+85673075|Stoeng Treng|ខេត្តស្ទឹងត្រែង
+85673081|Krachen|ខេត្ត ក្រចេះ
+85673085|Mondol Kiri|Môndôl Kiri
+85673089|Khétt Rôtânôkiri|Ratanah Kiri
+85673093|Kampot|ខេត្តកំពត
+85673099|Keb|Khétt Kêb
+85673101|Khétt Preăh Seihânŭ|Preah Seihanu
+85673105|Svay Rieng|ខេត្តស្វាយរៀង
+85673107|Takev|ខេត្តតាកែវ
+85673173|Chungcheongbuk-Do|충청북도
+85673177|Incheon|인천
+85673181|Kangwon-Do|강원도
+85673185|Seoul|서울
+85673191|Kyeongki-Do|경기도
+85673195|Jeollabuk-Do|전라북도
+85673199|Gwangju|광주
+85673203|Chungcheongnam-Do|충청남도
+85673207|Daejon|대전
+85673213|Daegu|대구
+85673215|Gyeongsangnam-Do|경상남도
+85673219|Jeollanam-Do|전라남도
+85673227|Busan|부산
+85673231|Ulsan|울산
+85673233|Gyeongsangbuk-Do|경상북도
+85673237|Jaeju-Do|제주도
+85673243|Chungcheongnam-Do|세종
+85673253|Klina|Pech|Клина
+85673267|Pech|Rahoveci|Ораховац
+85673299|Kosovska Mitrovica|Zubin Potoku|Зубин Поток
+85673303|Fushë Kosova|Kosovo|Косово Поље
+85673307|Drenasi|Kosovo|Глоговац
+85673317|Besiana|Kosovo|Подујево
+85673321|Kosovo|Prishtina|Приштина
+85673325|Kosovo|Lipjani|Липљан
+85673335|Kosovsko Pomoravlje|Vitia|Витина
+85673339|Artana|Kosovsko Pomoravlje|Ново Брдо
+85673383|Al Asimah|العاصمة‎
+85673389|Al Farwaniyah|الفروانية‎
+85673391|Al Ahmadi|الأحمدي‎
+85673395|Mubarak Al-Kabeer|مبارك الكبير
+85673399|Al Jahrah|الجهراء‎
+85673405|Hawalli|حولي‎
+85673409|Bokeo|ແຂວງບໍ່ແກ້ວ
+85673413|Louang Namtha Province|ແຂວງຫຼວງນໍ້າທາ
+85673417|Xiagnabouli|ແຂວງໄຊຍະບູລີ
+85673423|Champasak|ຈຳປາສັກ
+85673427|Salavan|ແຂວງສາລະວັນ
+85673429|Savannahkhet|ແຂວງສະຫວັນນະເຂດ
+85673433|Viangchan|ນະຄອນຫຼວງວຽງຈັນ
+85673437|Viangchan|ນະຄອນຫຼວງວຽງຈັນ
+85673441|Xiangkhoang|ແຂວງຊຽງຂວາງ
+85673447|Houaphan|ຫົວພັນ
+85673451|Louangphabang|ແຂວງຫຼວງພະບາງ
+85673453|Oudomxai|ແຂວງອຸດົມໄຊ
+85673459|Phongsali|ແຂວງຜົ້ງສາລີ
+85673463|Bolikhamxai|ແຂວງບໍລິຄໍາໄຊ
+85673467|Khammouan|ແຂວງຄຳມ່ວນ
+85673469|Attapu|ແຂວງ​ອັດຕະປື
+85673473|Xekong|ແຂວງເຊກອງ
+85673479|Beqaa|البقاع
+85673483|North Lebanon|الشمال
+85673487|Beirut|بيروت
+85673491|Mount Lebanon|جبل لبنان
+85673495|Nabatieh|النبطية
+85673499|South Lebanon|الجنوب
+85673563|Ghadamis|غدامس
+85673567|Al Jufrah|الجفرة
+85673571|Al Kufrah|الكفرة
+85673575|Al Khums|الخمس
+85673579|Ash Shati'|وادي الشاطئ
+85673585|Awbari|غات
+85673589|Murzuq|مرزق
+85673593|Misratah|مصراتة
+85673597|Sabha|سبها
+85673605|Al Jifarah|العزيزية/الجفرة
+85673607|An Nuqat al Khams|النقاط الخمس
+85673611|Az Zawiyah|الزاوية
+85673615|Gharyan|مزدة
+85673621|Tajura' wa an Nawahi al Arba|تاجوراء والنواحي الأربع‎
+85673625|Al Marj|المرج
+85673627|Al Jabal al Akhdar|الجبل الاخضر
+85673631|Ajdabiya|أجدابيا
+85673635|Benghazi|بنغازي
+85673659|Surt|سرت
+85673663|Darnah|القبة
+85673665|Al Butnan|البطنان
+85673669|Awbari|أوباري
+85673719|Kandy|கண்டி மாவட்டம்|මහනුවර දිස්ත් රික්කය
+85673723|Matale|மாத்தளை மாவட்டம்|මාතලේ පරිපාලන දිස්ත් රික්කය
+85673731|Nuwara Eliya|நுவரெலியா மாவட்டம்|නුවරඑළිය පරිපාලන දිස්ත්‍රික්කය
+85673733|Ampara|அம்பாறை மாவட்டம்|අම්පාර පරිපාලන දිස්ත්‍රික්කය
+85673737|Batticaloa|மட்டக்களப்பு மாவட்டம்|මඩකලපුව පරිපාලන දිස්ත්‍රික්කය
+85673743|Polonnaruwa|பொலன்னறுவை மாவட்டம்|පොළොන්නරුව දිස්ත්‍රික්කය
+85673747|Trincomalee|திருகோணமலை மாவட்டம்|ත්‍රිකුණාමල දිස්ත්‍රික්කය
+85673751|Anuradhapura|அனுராதபுரம் மாவட்டம்|අනුරාධපුර පරිපාලන දිස්ත්‍රික්කය
+85673757|Vavuniya|வவுனியா|වවුනියාව
+85673761|Mannar|மன்னார் மாவட்டம்|මන්නාරම් දිස්ත්‍රික්කය
+85673765|Mullaitivu|முல்லைத்தீவு|මුලතිව්
+85673769|Jaffna|யாழ்ப்பாண மாவட்டம்|යාපනය පරිපාලන දිස්ත්‍රික්කය
+85673773|Kilinochchi|கிளிநொச்சி மாவட்டம்|කිලිනොච්චි දිස්ත්‍රික්කය
+85673777|Kurunegala|குருநாகல் மாவட்டம்|කුරුණෑගල දිස්ත් රික්කය
+85673779|Puttalam|புத்தளம்|පුත්තලම දිස්ත්‍රික්කය
+85673785|Ratnapura|இரத்தினபுரி மாவட்டம்|රත්නපුර දිස්ත් රික්කය
+85673789|Galle|காலி மாவட்டம்|ගාල්ල පරිපාලන දිස්ත්‍රික්කය
+85673791|Hambantota|அம்பாந்தோட்டை மாவட்டம்|හම්බන්තොට පරිපාලන දිස්ත්‍රික්කය
+85673795|Matara|மாத்தறை மாவட்டம்|මාතර දිස්ත්‍රික්කය
+85673801|Badulla|பதுளை மாவட்டம்|බදුල්ල පරිපාලන දිස්ත්‍රික්කය
+85673803|Moneragala|மொனராகலை மாவட்டம்|මොණරාගල දිස්ත්‍රික්කය
+85673807|Kegalle|கேகாலை மாவட்டம்|කෑගල්ල පරිපාලන දිස්ත්‍රික්කය
+85673811|Colombo|கொழும்பு மாவட்டம்|කොළඹ දිස්ත් රික්කය
+85673815|Gampaha|கம்பகா மாவட்டம்|ගම්පහ පරිපාලන දිස්ත්‍රික්කය
+85673819|Kalutara|களுத்துறை மாவட்டம்|කළුතර පරිපාලන දිස්ත්‍රික්කය
+85673865|Diekirch|Diekirch District|Dikrech
+85673869|Grevenmacher|Grevenmacher District|Gréiwemaacher
+85673875|Luxembourg|Luxemburg|Lëtzebuerg
+85673883|Tanger-Tétouan|Tangier-Tetouan|طنجة ـ تطوان
+85673887|Fes-Boulemane|Fès-Boulemane|مكناس ـ تافيلالت
+85673893|Taza-Al Hoceima-Taounate|Taza-Al Hoceïma-Taounate|تازة ـ الحسيمة ـ تاونات
+85673897|Gharb-Chrarda-Béni Hssen|الغرب ــ الشراردة ــ بني حسن
+85673901|Chaouia - Ouardigha|Chaouia-Ouardigha|الشاوية
+85673905|Grand Casablanca|Greater Casablanca|الدار البيضاء الكبرى
+85673911|Rabat-Salé-Zemmour-Zaer|الرباط - سلا - زمور- زعير
+85673915|Meknès-Tafilalet|مكناس ـ تافيلالت
+85673919|Tadla - Azilal|Tadla-Azilal|تادلة ـ أزيلال
+85673923|Oriental|الجهة الشرقية
+85673929|Souss-Massa-Drâa|Suss-Massa-Draa|سوس ـ ماسة ـ درعة
+85673933|Marrakech - Tensift - Al Haouz|Marrakech-Tensift-Al Haouz|مراكش ـ تانسيفت ـ الحوز
+85673937|Doukkala - Abda|Doukkala-Abda|دكالة عبدة
+85673941|Laâyoune-Boujdour-Sakia El Hamra|Laâyoune-Boujdour-Sakia el Hamra|جهة العيون بوجدور
+85673947|Guelmim - Es-Semara|Guelmim-Es-Semara|كلميم ـ السمارة
+85673951|Oued Ed-Dahab|إقليم وادي
+85673955|Alaotra-Mangoro|Toamasina
+85673959|Amoron'i Mania|Fianarantsoa
+85673965|Analamanga|Antananarivo
+85673967|Analanjirofo|Toamasina
+85673973|Androy|Toliara
+85673977|Anosy|Toliara
+85673983|Atsimo-Andrefana|Toliara
+85673987|Atsimo-Atsinanana|Fianarantsoa
+85673991|Atsinanana|Toamasina
+85673995|Betsiboka|Mahajanga
+85674001|Boeny|Mahajanga
+85674005|Antananarivo|Bongolava
+85674009|Antsiranana|Diana
+85674013|Fianarantsoa|Haute Matsiatra|Matsiatra Ambony
+85674019|Fianarantsoa|Ihorombe
+85674025|Antananarivo|Itasy
+85674029|Mahajanga|Melaky
+85674035|Menabe|Toliara
+85674037|Antsiranana|Sava
+85674041|Mahajanga|Sofia
+85674043|Antananarivo|Vakinankaratra
+85674045|Fianarantsoa|Vatovavy-Fitovinany
+85674049|Haa Alifu|ތިލަދުންމަތީ އުތުރުބުރި
+85674053|Haa Dhaalu|ތިލަދުންމަތީ ދެކުނުބުރި
+85674057|Shaviyani|މިލަދުންމަޑުލު އުތުރުބުރި
+85674061|Raa|މާޅޮސްމަޑުލު އުތުރުބުރި
+85674063|Noonu|މިލަދުންމަޑުލު ދެކުނުބުރި
+85674073|Lhaviyani|ފާދިއްޕޮޅު
+85674077|Kaafu|މާލެ އަތޮޅު
+85674089|Faafu|ނިލަންދެއަތޮޅު އުތުރުބުރި
+85674097|Vaavu|ފެލިދެ އަތޮޅު
+85674101|Meemu|މުލަކަތޮޅު
+85674107|Dhaalu|ނިލަންދެއަތޮޅު ދެކުނުބުރި
+85674111|Thaa|ކޮޅުމަޑުލު
+85674115|Laamu|ހައްދުންމަތި
+85674121|Gaafu Alifu|ހުވަދުއަތޮޅު އުތުރުބުރި
+85674125|Gaafu Dhaalu|ހުވަދުއަތޮޅު ދެކުނުބުރި
+85674133|Gnaviyani|ޏ. އަތޮޅު
+85674135|Seenu|އައްޑުއަތޮޅު
+85674147|Resen Municipality|Општина Ресен
+85674151|Vevcani Municipality|Општина Вевчани
+85674157|Bitola Municipality|Општина Битола
+85674161|Demir Hisar Municipality|Општина Демир Хисар
+85674165|Ohrid Municipality|Општина Охрид
+85674169|Debarca Municipality|Opština Debarca
+85674173|Petrovec Municipality|Општина Петровец
+85674179|Plasnica Municipality|Општина Пласница
+85674183|Prilep Municipality|Општина Прилеп
+85674187|Probistip Municipality|Општина Пробиштип
+85674191|Radovis Municipality|Општина Радовиш
+85674197|Kriva Palanka Municipality|Општина Крива Паланка
+85674201|Rosoman Municipality|Општина Росоман
+85674205|Saraj Municipality|Општина Сарај
+85674209|Sopiste Municipality|Општина Сопиште
+85674215|Staro Nagoricane Municipality|Општина Старо Нагоричане
+85674219|Stip Municipality|Општина Штип
+85674223|Studenicani Municipality|Општина Студеничани
+85674227|Cair Municipality|Општина Чаир
+85674229|Sveti Nikole Municipality|Општина Свети Николе
+85674237|Veles Municipality|Општина Велес
+85674241|Vranestica Municipality|Општина Вранештица
+85674245|Zelenikovo Municipality|Општина Зелениково
+85674251|Zelino Municipality|Општина Желино
+85674253|Aracinovo Municipality|Општина Арачиново
+85674257|Lipkovo Municipality|Општина Липково
+85674261|Butel Municipality|Opština Butel
+85674265|Caska Municipality|Општина Чашка
+85674273|Centar Municipality|Општина Центар
+85674275|Zrnovci Municipality|Општина Зрновци
+85674279|Cesinovo-Oblesevo Municipality|Општина Чешиново-Облешево
+85674287|Cucer-Sandevo Municipality|Општина Чучер Сандево
+85674289|Demir Kapija Municipality|Општина Демир Капија
+85674293|Dolneni Municipality|Општина Долнени
+85674297|Gazi Baba Municipality|Општина Гази Баба
+85674301|Gradsko Municipality|Општина Градско
+85674307|Lozovo Municipality|Општина Лозово
+85674311|Konce Municipality|Општина Конче
+85674315|Ilinden|Ilinden Municipality
+85674319|Karbinci Municipality|Општина Карбинци
+85674323|Karpos Municipality|Општина Карпош
+85674327|Kavadarci Municipality|Кавадарци
+85674331|Aerodrom Municipality|Opština Aerodrom
+85674337|Centar Municipality|Општина Кисела Вода
+85674341|Kocani Municipality|Општина Кочани
+85674345|Kratovo Municipality|Кратово
+85674349|Krivogastani Municipality|Општина Кривогаштани
+85674353|Krusevo Municipality|Општина Крушево
+85674355|Kumanovo Municipality|Општина Куманово
+85674361|Makedonski Brod Municipality|Општина Македонски Брод
+85674365|Mogila Municipality|Општина Могила
+85674369|Negotino Municipality|Општина Неготино
+85674373|Novaci Municipality|Општина Новаци
+85674377|Gjorce Petrov Municipality|Општина Ѓорче Петров
+85674381|Zajas Municipality|Општина Зајас
+85674385|Centar Zupa Municipality|Општина Центар Жупа
+85674389|Debar Municipality|Општина Дебар
+85674395|Drugovo Municipality|Општина Другово
+85674399|Kicevo Municipality|Општина Кичево
+85674403|Mavrovo and Rostusa Municipality|Општина Маврово и Ростуша
+85674407|Oslomej Municipality|Општина Осломеј
+85674413|Tearce Municipality|Општина Теарце
+85674417|Tetovo Municipality|Општина Тетово
+85674421|Vrapciste Municipality|Општина Врапчиште
+85674425|Bogovinje Municipality|Општина Боговиње
+85674427|Brvenica Municipality|Општина Брвеница
+85674433|Gostivar Municipality|Гостивар
+85674437|Jegunovce Municipality|Општина Јегуновце
+85674439|Strumica Municipality|Општина Струмица
+85674443|Valandovo Municipality|Општина Валандово
+85674449|Vasilevo Municipality|Општина Василево
+85674453|Bogdanci Municipality|Општина Богданци
+85674457|Bosilovo Municipality|Општина Босилово
+85674461|Gevgelija Municipality|Општина Гевгелија
+85674467|Novo Selo Municipality|Општина Ново Село
+85674473|Star Dojran Municipality|Општина Дојран
+85674475|Vinica Municipality|Општина Виница
+85674479|Berovo Municipality|Општина Берово
+85674485|Delcevo Municipality|Општина Делчево
+85674489|Makedonska Kamenica Municipality|Општина Македонска Каменица
+85674495|Pehcevo Municipality|Општина Пехчево
+85674497|Struga Municipality|Општина Струга
+85674503|Rankovce Municipality|Општина Ранковце
+85674507|Centar Municipality|Шуто Оризари
+85674557|Karan State|ကရင်ပြည်နယ်
+85674559|Mandalay|မန္တလေးတိုင်း
+85674565|Bago|ပဲခူးတိုင်းဒေသကြီး
+85674569|Yangon|ရန်ကုန်တိုင်းဒေသကြီး
+85674575|Mon State|မွန်ပြည်နယ်
+85674579|Rakhine State|ရခိုင် ပြည်နယ်
+85674581|Chin State|ချင်းပြည်နယ်‌
+85674585|Ayeyarwady|ဧ​ရာဝတီတိုင်း
+85674589|Magway|မကွေးတိုင်း
+85674595|Shan State|ရှမ်းပြည်နယ်
+85674599|Tenasserim|တနင်္သာရီမြို့
+85674605|Kachin State|ကချင်ပြည်နယ်
+85674607|Sagaing|စစ်ကိုင်းတိုင်း
+85674613|Bar|Општина Бар
+85674617|Ulcinj|Улцињ
+85674621|Budva|Општина Будва
+85674625|Cetinje|Општина Цетиње
+85674633|Rozaje|Рожаје
+85674635|Plav|Плав
+85674639|Herceg Novi|Херцег Нови
+85674643|Kotor|Котор
+85674649|Andrijevica|Андријевица
+85674653|Berane|Општина Беране
+85674657|Bijelo Polje|Бијело Поље
+85674661|Danilovgrad|Оптшина Даниловград
+85674667|Kolasin|Општина Колашин
+85674669|Mojkovac|Општина Мојковац
+85674673|Niksic|Општина Никшић
+85674677|Pluzine|Општина Плужине
+85674685|Pljevlja|Пљевља
+85674689|Podgorica|Подгорица
+85674693|Tivat|Општина Тиват
+85674695|Savnik|Општина Шавник
+85674701|Zabljak|Општина Жабљак
+85674705|Bayan-Olgiy|Баян-Өлгий Аймаг
+85674709|Dornogovi|Дорноговь Аймаг
+85674713|Omnogov|Өмнөговь Аймаг
+85674719|Hentiy|Хэнтий Аймаг
+85674721|Arhangay|Архангай Аймаг
+85674723|Bayanhongor|Баянхонгор Аймаг
+85674727|Dzavhan|Завхан Аймаг
+85674731|Govi-Altay|Говь-Алтай Аймаг
+85674737|Hovd|Ховд Аймаг
+85674741|Hovsgol|Хөвсгөл Аймаг
+85674745|Uvs|Увс Аймаг
+85674749|Bulgan|Булган Аймаг
+85674751|Erdenet|Орхон
+85674757|Dundgovi|Дундговь Аймаг
+85674761|Selenge|Сэлэнгэ Аймаг
+85674765|Ovorhangay|Өвөрхангай Аймаг
+85674769|Darhan|Darhan-Uul Aymag
+85674777|Tov|Төв Аймаг
+85674779|Govĭsümber Aymag|Tov
+85674787|Dornod|Дорнод Аймаг
+85674793|Suhbaatar|Сүхбаатар Аймаг
+85674857|Tiris Zemmour|ولاية تيرس زمور
+85674863|Brakna Region|ولاية البراكنة
+85674865|Dakhlet Nouadhibou|داخلة نواذيبو
+85674869|Inchiri Region|ولاية إينشيري
+85674873|Nouakchott|نواكشوط
+85674881|Trarza|ولاية الترارزة
+85674885|Assaba Region|ولاية العصابة
+85674887|Guidimaka Region|ولاية كيدي ماغة
+85674891|Gorgol Region|ولاية كركول
+85674899|Adrar Region|ولاية آدرار
+85674901|Hodh ech Chargui|ولاية الحوض الشرقي
+85674905|Hodh el Gharbi|ولاية الحوض الغربي
+85674909|Tagant Region|ولاية تكانت
+85674925|Agalega Islands|Agaléga
+85674929|Beau Bassin|Beau Bassin-Rose Hill
+85674935|Cargados Carajos|Saint-Brandon
+85674939|Curepipe|Curepipe (2)
+85674971|Port Louis|Port-Louis
+85674979|Riviere du Rempart|Rivière du Rempart
+85674983|Black River|Rivière Noire
+85674997|Vacoas|Vacoas-Phœnix
+85675195|Karas|ǀǀKaras
+85675217|Otjozondjoepa|Otjozondjupa
+85675223|Omoesati|Omusati
+85675227|Oshana|Osjana
+85675243|Oshikoto|Osjikoto
+85675269|Diffa|Diffa Region
+85675301|Borno|Ìpínlẹ̀ Bọ̀rnó
+85675305|Abia|Ìpínlẹ̀ Ábíá
+85675309|Akwa Ibom|Ìpínlẹ̀ Akwa Íbọm
+85675315|Imo|Ìpínlẹ̀ Ímò
+85675317|Rivers|Ìpínlẹ̀ Rivers
+85675321|Bayelsa|Ìpínlẹ̀ Bàyélsà
+85675325|Benue|Ìpínlẹ̀ Bẹ́núé
+85675331|Cross River|Ìpínlẹ̀ Cross River
+85675335|Taraba|Ìpínlẹ̀ Tàràbà
+85675339|Kwara|Ìpínlẹ̀ Kúárà
+85675343|Lagos|Èkó
+85675349|Niger|Ìpínlẹ̀ Niger
+85675353|Ogun|Ìpínlẹ̀ Ògùn
+85675357|Ondo|Ìpínlẹ̀ Òndó
+85675361|Ekiti|Ìpínlẹ̀ Èkìtì
+85675367|Osun|Ìpínlẹ̀ Ọ̀ṣun
+85675371|Oyo|Ìpínlẹ̀ Ọ̀yọ́
+85675375|Anambra|Ìpínlẹ̀ Anámbra
+85675379|Bauchi|Ìpínlẹ̀ Bauchi
+85675381|Gombe|Ìpínlẹ̀ Gòmbè
+85675387|Delta|Ìpínlẹ̀ Dẹ́ltà
+85675391|Edo|Ìpínlẹ̀ Ẹdó
+85675395|Enugu|Ìpínlẹ̀ Ẹnúgu
+85675399|Ebonyi|Ìpínlẹ̀ Ẹ̀bọ́nyì
+85675405|Kaduna|Ìpínlẹ̀ Kàdúná
+85675407|Kogi|Ìpínlẹ̀ Kogí
+85675411|Plateau|Ìpínlẹ̀ Plateau
+85675415|Nassarawa|Ìpínlẹ̀ Násáráwá
+85675421|Jigawa|Ìpínlẹ̀ Jígàwà
+85675425|Kano|Ìpínlẹ̀ Kánò
+85675429|Katsina|Ìpínlẹ̀ Kàtsínà
+85675433|Sokoto|Ìpínlẹ̀ Sókótó
+85675439|Zamfara|Ìpínlẹ̀ Zamfara
+85675443|Yobe|Ìpínlẹ̀ Yòbè
+85675447|Kebbi|Ìpínlẹ̀ Kébbí
+85675451|Adamawa|Ìpínlẹ̀ Adámáwá
+85675457|Agbègbè Olúìlú Ìjọba Àpapọ̀ Abùjá|Federal Capital Territory
+85675465|Rio San Juan|Río San Juan
+85675467|Atlántico Sur|Región Autónoma del Caribe Sur
+85675485|Atlántico Norte|Región Autónoma del Caribe Norte
+85675567|Mahakali|महाकाली अञ्चल
+85675571|Seti|सेती अञ्चल
+85675579|Janakpur|जनकपुर अञ्चल
+85675585|Narayani|नारायणी अञ्चल
+85675589|Sagarmatha|सगरमाथा अञ्चल
+85675681|Ad Dakhiliyah|الداخلية
+85675685|Al Wusta|الوسطى
+85675691|Ash Sharqiyah|الشرقية
+85675695|Zufar|ظفار
+85675699|Az Zahirah|الظاهرة
+85675703|Al Batinah|الباطنة
+85675709|Musandam|مسندم
+85675713|Masqat|مسقط
+85675717|Buraymi|البريمي
+85675721|Ash Sharqiyah|الشرقية
+85675727|Al Batinah|الباطنة
+85675733|Balochistan|بلوچستان‬
+85675735|Azad Kashmir|आज़ाद कश्मीर
+85675741|Islamabad|آزاد جموں و کشمیر‬
+85675745|Gilgit Baltistan|گلگت بلتستان‬
+85675749|Federally Administered Tribal Areas|قبائلی علاقہ جات
+85675753|Punjab|پنجاب‬
+85675757|Sindh|سندھ‬
+85675763|North-West Frontier|سرحدی صوبہسنڌ
+85675789|Panama|Panamá
+85675807|Ngäbe Buglé|Ngöbe Buglé
+85675817|Callao|Qallaw Suyu
+85675821|Lambayeque|Lampalliqi Suyu
+85675827|Piura|Piwra Suyu
+85675831|Tumbes|Tumpis Suyu
+85675835|Apurimac|Apurimaq Suyu|Apurímac
+85675839|Arequipa|Ariqipa Suyu
+85675843|Cusco|Qusqu Suyu
+85675847|Amaru suyu|Madre de Dios
+85675853|Callao|Puno
+85675857|Moquegua|Muqiwa suyu
+85675861|Tacna|Taqna Suyu
+85675865|Ancash|Anqash Suyu
+85675871|Cajamarca|Kashamarka Suyu
+85675875|Huanuco|Huánuco|Wanuku Suyu
+85675879|La Libertad|Qispikay suyu
+85675883|Pasco|Pasqu Suyu
+85675885|San Martin|San Martin Suyu|San Martín
+85675891|Ucayali|Ukayali Suyu
+85675895|Amarumayu Suyu|Amazonas
+85675899|Loreto|Luritu Suyu
+85675903|Ayacucho|Ayakuchu Suyu
+85675909|Ancha llaqta Limaq|Lima Metropolitan Area|Lima Province
+85675911|Huancavelica|Wankawillka suyu
+85675915|Ica|Ika Suyu
+85675919|Hunin Suyu|Junin|Junín
+85675925|Lima|Lima Suyu|Lima region
+85676161|Lalawigan ng Quezon|Quezon
+85676259|Province of Sarangani|Sarangani
+85676277|Isabela|Lungsod ng Isabela
+85676327|Caraga|Lungsod ng Butuan
+85676519|East Sepik|Is Sepik
+85676531|Chimbu|Simbu
+85676533|Eastern Highlands|Isten Hailans
+85676539|Gulf|Gulf Provins
+85676547|Sauten Hailans|Southern Highlands
+85676551|Westen Hailans|Western Highlands
+85676557|Westen Provins|Western
+85676561|Central|Sentral Provins
+85676565|East New Britain|Is Niu Briten
+85676575|Milen Be|Milne Bay
+85676581|National Capital|Nesenel Kapitol Distrik
+85676587|New Ireland|Niu Ailan
+85676595|Northern|Oro
+85676599|Wes Niu Briten|West New Britain
+85676603|Hwanghae-bukto|황해북도
+85676605|Hwanghae-namdo|황해남도
+85676611|P´yongyang-si|평양
+85676615|Hamgyong-bukto|함경북도
+85676619|Kangwon-do|강원도
+85676623|Chagang-do|자강도
+85676629|Hamgyong-namdo|함경남도
+85676633|P'yongan-bukto|평안북도
+85676637|P'yongan-namdo|평안남도
+85676641|Yanggang-do|양강도
+85676647|Hamgyong-bukto|나선
+85676651|Asunción|Paraguay
+85676655|Alto Paraguay|Alto Paraguái
+85676665|Concepción|Tetãvore Concepción
+85676671|Presidente Hayes|Tetãvore Presidente Hayes
+85676675|San Pedro|Tetãvore San Pedro
+85676681|Central|Tetãvore Central
+85676685|Guaira|Guairá
+85676691|Ñe'ẽmbuku|Ñeembucú
+85676699|Paraguarí|Tetãvore Paraguari
+85676701|Amambai|Amambay
+85676705|Alto Parana|Alto Paraná
+85676709|Caaguazú|Ka'aguasu
+85676713|Caazapá|Tetãvore Ka'asapa
+85676719|Canindeyú|Kanindeju
+85676749|Doha|الدوحة
+85676755|Al Rayyan|الريان
+85676759|Al Wakra|الوكرة
+85676767|Al Khor|الخور
+85676773|Madinat Al Shamal|مدينة الشمال
+85676777|Umm Slal|أم صلال
+85676781|Umm Slal|الضعاين‎
+85676785|Intara y’ Amajyepfo|Province du Sud|Southern
+85676791|Intara y’ Iburengerazuba|Province de l'Ouest|Western
+85676795|Eastern|Intara y’ Iburasirazuba|Province de l'Est
+85676799|Intara y’ Amajyaruguru|Northern|Province du Nord
+85676807|Kigali|Kigali Province
+85676809|Najran|نجران
+85676813|Riyadh|الرياض
+85676819|Eastern Province|الشرقية
+85676825|Al Madinah|المدينة
+85676827|Al-Qassim|القصيم
+85676831|Ha'il|حائل
+85676833|Tabuk|تبوك
+85676837|Northern Borders|الحدود الشمالية
+85676843|Al Jawf|الجوف
+85676847|Al-Bahah|الباحة
+85676851|Aseer|عسير
+85676853|Jizan|جازان
+85676857|Makkah|مكة
+85676865|An Nil al Azraq|النيل الأزرق
+85676867|Al Bahr al Ahmar|البحر الأحمر
+85676871|Janub Darfor|جنوب دارفور
+85676875|Janub Darfor|شرق دارفور
+85676881|Gharb Darfor|غرب دارفور
+85676885|Gharb Darfor|وسط دارفور
+85676889|Al Khartum|الخرطوم
+85676893|Gezira|الجزيرة
+85676897|Gadarif|القضارف
+85676901|Nahr an Nil|نهر النيل‎ 
+85676905|Ash Shamaliyah| ولاية الشمالية
+85676909|An Nil al Abyad| النيل الأبيض‎ 
+85676915|Sinnar|سنار‎
+85676919|Shamal Darfor|شمال دارفور
+85676923|Janub Kurdufan|جنوب كردفان
+85676925|Shamal Kurdufan|شمال كردفان
+85676929|Ash Sharqiyah|كسلا
+85676979|Diiwaanu Koldaa|Sedhiou|Sédhiou
+85676983|Diiwaanu Kéedugu|Kedougou|Kédougou
+85676989|Diiwaanu Kafrin|Kaffrine
+85676993|Diiwaanu Ndar|Saint-Louis
+85676997|Dakar|Diiwaanu Ndakaaru
+85677001|Diiwaanu Njaaréem|Diourbel
+85677007|Diiwaanu Fatik|Fatick
+85677011|Diiwaanu Kawlax|Kaolack
+85677015|Diiwaanu Luga|Louga
+85677019|Diiwaanu Maatam|Matam
+85677025|Diiwaanu Cees|Thies|Thiès
+85677027|Diiwaanu Koldaa|Kolda
+85677033|Diiwaanu Siggcoor|Ziguinchor
+85677035|Diiwaanu Tambaakundaa|Tambacounda
+85677041|Central Singapore|Singapura Tengah|中区
+85677045|Barat Daya|South West|西南区
+85677049|Barat Laut|North West|西北区
+85677053|North East|Timur Laut|东北区
+85677059|South East|Timur Selatan|东南区
+85677235|Bari|باري
+85677241|Bakool|باكول
+85677245|Baay|Bay|باي
+85677249|Gedo|جدو
+85677253|Jubbada Dhexe|جوبا الوسطى
+85677259|Shabeellaha Hoose|شبيلي السفلى
+85677263|Banaadir|بنادر
+85677267|Galguduud|جلجدود
+85677269|Hiiraan|هيران
+85677275|Shabeellaha Dhexe|شبيلا الوسطى
+85677279|Mudug|مدج
+85677283|Gobolka Nugaal|Nugaal|نوغال
+85677287|Gobolka Jubbada Hoose|Jubbada Hoose|جوبا السفلى
+85677301|São Tomé|São Tomé Island
+85677373|Občina Vuzenica|Vuzenica
+85677375|Občina Zagorje ob Savi|Zasavska
+85677385|Bled|Občina Radovljica
+85677443|Municipality of Škofja Loka|Občina Škofja Loka
+85677447|Občina Tolmin|Tolmin
+85677483|Hrpelje-Kozina|Občina Hrpelje - Kozina
+85677487|Izola|Občina Izola
+85677503|Koper|Mestna občina Koper
+85677509|Miren-Kostanjevica|Občina Miren - Kostanjevica
+85677513|Občina Piran|Piran
+85677595|Občina Sveta Ana|Sveta Ana
+85677621|Kamnik|Občina Kamnik
+85677627|Lenart|Občina Lenart
+85677657|Mestna občina Novo mesto|Novo Mesto
+85677663|Občina Podvelka|Podvelka
+85677671|Mestna občina Ptuj|Ptuj
+85677677|Občina Ribnica|Ribnica
+85677685|Municipality of Šentjur|Občina Šentjur
+85677717|Hajdina|Občina Hajdina
+85677743|Občina Prevalje|Prevalje
+85677825|Dobrepolje|Občina Dobrepolje
+85677839|Maribor|Mestna občina Maribor
+85677847|Jesenice|Občina Jesenice
+85677871|Lendava|Občina Lendava
+85677875|Ljutomer|Občina Ljutomer
+85677899|Dobrovnik|Občina Dobrovnik
+85677923|Gornja Radgona|Občina Gornja Radgona
+85677951|Krsko|Občina Krško
+85677961|Celje|Mestna občina Celje
+85677967|Cerknica|Občina Cerknica
+85677985|Dravograd|Občina Dravograd
+85677989|Duplek|Občina Duplek
+85677999|Grosuplje|Občina Grosuplje
+85678003|Hrastnik|Občina Hrastnik
+85678013|IG|Ig
+85678017|Ilirska Bistrica|Občina Ilirska Bistrica
+85678025|Kidricevo|Kidričevo
+85678037|Kungota|Občina Kungota
+85678051|Ljubljana|Mestna občina Ljubljana
+85678059|Logatec|Občina Logatec
+85678069|Lukovica|Občina Lukovica
+85678095|Mozirje|Občina Mozirje
+85678109|Občina Pesnica|Pesnica
+85678175|Mestna občina Slovenj Gradec|Slovenj Gradec
+85678205|Občina Trebnje|Trebnje
+85678229|Sint Maarten|Sint Maarten (land)
+85678233|Outer Islands|Îles Extérieures
+85678247|Anse Etoile|Anse Étoile
+85678265|Baie Sainte-Anne|Baie Ste. Anne
+85678277|Bel Ombre|Belombre
+85678291|Grand Anse Mahe|Grand'Anse
+85678295|Grand Anse Praslin|Grand'Anse
+85678301|La Digue and Inner Islands|La Digue et les îles intérieures
+85678305|English River|La Rivière Anglaise
+85678323|Pointe La Rue|Pointe Larue
+85678341|Roche Caiman|Roche Caïman
+85678345|Al Ladhiqiyah|Lattaquié|اللاذقية
+85678349|Tartous|Tartus|طرطوس
+85678355|Ar Raqqah|Racca|الرقة
+85678359|Alep|H'alab|حلب
+85678363|Hama|Hamah|حماة
+85678367|Homs|Homs (Hims)|حمص
+85678373|Idleb|Idlib|إدلب
+85678377|Hasaka (Al Haksa)|Hassaké|الحسكة
+85678381|Dayr az Zawr|Deir ez-Zor|دير الزور
+85678385|As Suwayda'|Soueïda|السويداء
+85678391|Rif Dimashq|ريف دمشق
+85678395|Al Qunaytirah|מחוז קוניטרה|القنيطرة
+85678399|Dar`a|Deraa|دِرعا
+85678403|Damas|Dimashq|دمشق
+85678435|Hadjer-Lamis|حجر لميس
+85678439|Kanem|Kanem Region|كانم
+85678445|Lac|Lac Region|البحيرة
+85678449|Batha|Batha Region|البطحة
+85678453|Wadi Fira|Wadi Fira Region|وادي فيرا
+85678457| قيرا|Guéra|Guéra Region
+85678463|Ouadaï Region|Ouaddaï|وداي
+85678467|Logone Occidental|لوقون الغربي
+85678469| لوقون الشرقي|Logone Oriental|Logone Oriental Region
+85678473|Mayo-Kebbi Est|مايو كيبي الشرقي
+85678477|Tandjilé|Tandjilé Region|تانجلي
+85678483|Mandoul|Mandoul Region|ماندول
+85678487|Salamat|Salamat Region|سلامات
+85678491|N'Djamena|N'Djaména|انجمينا
+85678495|Mayo-Kebbi Ouest|مايو كيبي الغربي
+85678501|Borkou|بركو
+85678505|Tibesti|تيبستي
+85678513|Chari-Baguirmi|كانم
+85678519|Bahr el-Ghazal|Barh El Gazel|إقليم بحر الغزال
+85678523|Sila|سيلا
+85678527|Moyen-Chari|شاري الأوسط
+85678531|Plateaux Region|Région des Plateaux
+85678537|Maritime Region|Région maritime
+85678541|Kara|Kara Region
+85678545|Centrale Region|Région centrale
+85678549|Région des Savanes|Savanes Region
+85678899|Kuhistoni Badakhshon|Вилояти Мухтори Кӯҳистони Бадахшон
+85678905|Khatlon|Вилояти Хатлон
+85678907|Karategin|Ноҳияҳои тобеи ҷумҳурӣ
+85678913|Leninobod|Вилояти Суғд
+85678917|Karategin|Душанбе
+85678923|Balkan welaýaty|Krasnovodsk
+85678925|Ahal welaýaty|Ashkhabad
+85678931|Daşoguz welaýaty|Tashauz
+85678937|Chardzhou|Lebap welaýaty
+85678941|Mary|Mary welaýaty
+85678943|Dili|Distritu Díli|Díli
+85678951|Distritu Liquiçá|Liquica|Liquiçá
+85678953|Distritu Oecussi-Ambeno|Oe-Cusse Ambeno|Oecussi-Ambeno
+85678957|Aileu|Distritu Aileu
+85678963|Ainaro|Distritu Ainaro
+85678967|Baucau|Distritu Baucau
+85678971|Bobonaro|Bobonaru
+85678975|Cova Lima|Distritu Cova Lima
+85678985|Distritu Manatuto|Manatuto
+85678993|Distritu Viqueque|Viqueque
+85678997|Distritu Lautém|Lautem|Lautém
+85679021|Eua|ʻEua
+85679095|Tozeur|توزر
+85679099|La Manouba|Manubah|منوبة
+85679103|Béja|باجة
+85679107|Ben Arous|Ben Arous (Tunis Sud)|بن عروس
+85679113|Bizerte|بَنْزَرْت‎
+85679115|Jendouba|جندوبة
+85679119|Nabeul|نابل
+85679123|Tunis|تونس
+85679131|Le Kef|الكاف
+85679133|Kasserine|Kassérine|القَصْرِين
+85679137|Gabès|قابس
+85679141|Gafsa|قفصة
+85679147|Sidi Bou Zid|سيدي بوزيد
+85679151|Sfax|صفاقس
+85679157|Siliana|سليانة‎
+85679161|Mahdia|المهدية
+85679165|Monastir|المنستير
+85679171|Kairouan|القَيْرَوَان
+85679173|Sousse|سوسة
+85679179|Zaghouan|زغوان
+85679183|Médenine|مدنين
+85679187|Kebili|قبلي
+85679191|Tataouine|تطاوين
+85679195|Aydin|Aydın
+85679201|Izmir|İzmir
+85679205|Balikesir|Balıkesir
+85679209|Canakkale|Çanakkale
+85679219|Kirklareli|Kırklareli
+85679223|Tekirdag|Tekirdağ
+85679237|Istanbul|İstanbul
+85679255|Eskisehir|Eskişehir
+85679283|Kutahya|Kütahya
+85679291|Mugla|Muğla
+85679295|Adiyaman|Adıyaman
+85679299|Elazig|Elazığ
+85679303|K. Maras|Kahramanmaraş
+85679317|Kirsehir|Kırşehir
+85679327|Nevsehir|Nevşehir
+85679339|Corum|Çorum
+85679387|Agri|Ağrı
+85679391|Bingol|Bingöl
+85679395|Diyarbakir|Diyarbakır
+85679401|Mus|Muş
+85679409|Ankara|Ankara Province
+85679413|Cankiri|Çankırı
+85679431|Usak|Uşak
+85679441|Sanliurfa|Şanlıurfa
+85679447|Kinkkale|Kırıkkale
+85679453|Nigde|Niğde
+85679465|Gumushane|Gümüşhane
+85679493|Sirnak|Şırnak
+85679515|Igdir|Iğdır
+85679533|Duzce|Düzce
+85679537|Karabuk|Karabük
+85679543|Bartin|Bartın
+85679547|Kaohsiung City|高雄縣
+85679549|Pingtung County|屏東縣
+85679553|Tainan City|台南市
+85679557|Hsinchu City|新竹市
+85679563|Hsinchu County|新竹縣
+85679567|Yilan County|宜蘭
+85679571|Keelung City|基隆市
+85679575|Miaoli County|苗栗縣
+85679583|Taipei City|台北市
+85679585|New Taipei City|新北市
+85679589|Taoyuan County|桃園
+85679593|Changhua County|彰化縣
+85679599|Chiayi County|嘉義縣
+85679603|Chiayi City|嘉義市
+85679607|Hualien County|花蓮縣
+85679611|Nantou County|南投
+85679617|Taichung City|台中市
+85679619|Yunlin County|雲林縣
+85679623|Taitung County|台東縣
+85679627|Penghu County|澎湖縣
+85679635|Kinmen County|金門縣
+85679637|Lienchiang County|連江縣
+85679641|Mbeya|Mkoa wa Mbeya
+85679645|Mkoa wa Rukwa|Rukwa
+85679651|Kusini Unguja|Zanzibar South and Central
+85679655|Mkoa wa Mwanza|Mwanza
+85679657|Mkoa wa Shinyanga|Shinyanga
+85679661|Mkoa wa Tabora|Tabora
+85679665|Kagera|Mkoa wa Kagera
+85679669|Kigoma|Mkoa wa Kigoma
+85679675|Dar es Salaam|Mkoa wa Dar es Salaam
+85679677|Mkoa wa Morogoro|Morogoro
+85679683|Kaskazini Pemba|Pemba North
+85679687|Kusini Pemba|Pemba South
+85679695|Kaskazini Unguja|Zanzibar North
+85679699|Mjini Magharibi|Zanzibar West
+85679705|Dodoma|Mkoa wa Dodoma
+85679711|Iringa|Mkoa wa Iringa
+85679713|Lindi|Mkoa wa Lindi
+85679717|Mkoa wa Mtwara|Mtwara
+85679723|Mkoa wa Ruvuma|Ruvuma
+85679727|Mkoa wa Singida|Singida
+85679731|Arusha|Mkoa wa Arusha
+85679733|Manyara|Mkoa wa Manyara
+85679737|Kilimanjaro|Mkoa wa Kilimanjaro
+85679743|Mara|Mkoa wa Mara
+85679747|Mkoa wa Tanga|Tanga
+85679751|Mkoa wa Rukwa|Rukwa
+85679755|Mkoa wa Shinyanga|Shinyanga
+85679761|Geita|Kagera
+85679769|Kalangala|Wilaya ya Kalangala
+85679773|Jinja|Wilaya ya Jinja
+85679777|Kumi|Wilaya ya Kumi
+85679789|Iganga|Wilaya ya Iganga
+85679795|Kamuli|Wilaya ya Kamuli
+85679807|Kaliro|Namutumba
+85679813|Soroti|Wilaya ya Soroti
+85679817|Mukono|Wilaya ya Mukono
+85679819|Pallisa|Wilaya ya Pallisa
+85679827|Mpigi|Wilaya ya Mpigi
+85679837|Arua|Wilaya ya Arua
+85679843|Buliisa|Masindi
+85679853|Moyo|Wilaya ya Moyo
+85679861|Arua|Wilaya ya Arua
+85679867|Kampala|Wilaya ya Kampala
+85679871|Kiboga|Wilaya ya Kiboga
+85679879|Wakiso|Wilaya ya Wakiso
+85679881|Luweero|Luwero
+85679891|Mityana|Wilaya ya Mityana
+85679895|Luwero|Nakaseke
+85679899|Kitgum|Wilaya ya Kitgum
+85679905|Gulu|Wilaya ya Gulu
+85679909|Lira|Wilaya ya Lira
+85679917|Pader|Wilaya ya Pader
+85679927|Oyam|Wilaya ya Oyam
+85679939|Kabarole|Wilaya ya Kabarole
+85679947|Kibaale|Wilaya ya Kibaale
+85679951|Kapchorwa|Wilaya ya Kapchorwa
+85679957|Bukwa|Kapchorwa
+85679965|Mbale|Wilaya ya Mbale
+85679969|Manafwa|Mbale
+85679979|Busia|Wilaya ya Busia
+85679989|Tororo|Wilaya ya Tororo
+85679995|Amuria|Katakwi
+85680003|Amuria|Katakwi
+85680007|Kaabong|Kotido
+85680017|Moroto|Wilaya ya Moroto
+85680021|Nakapiripirit|Wilaya ya Nakapiripirit
+85680025|Rakai|Wilaya ya Rakai
+85680031|Masaka|Wilaya ya Masaka
+85680035|Bushenyi|Wilaya ya Bushenyi
+85680037|Kasese|Wilaya ya Kasese
+85680051|Isingiro|Wilaya ya Isingiro
+85680069|Mbarara|Wilaya ya Mbarara
+85680073|Kabale|Wilaya ya Kabale
+85680075|Kisoro|Wilaya ya Kisoro
+85680085|Nebbi|Zombo
+85680095|Bukedea|Kumi
+85680097|Iganga|Wilaya ya Iganga
+85680107|Budaka|Wilaya ya Budaka
+85680111|Pallisa|Wilaya ya Pallisa
+85680125|Mukono|Wilaya ya Mukono
+85680139|Amuru|Gulu
+85680147|Kitgum|Wilaya ya Kitgum
+85680161|Alebtong|Lira
+85680165|Lira|Otuke
+85680169|Agago|Pader
+85680201|Moroto|Wilaya ya Moroto
+85680209|Amudat|Nakapiripirit
+85680215|Lyantonde|Masaka
+85680223|Kalungu|Masaka
+85680247|Gulu|Wilaya ya Gulu
+85680251|Bududa|Mbale
+85680325|Florida|Florida Department
+85680373|Bukhoro|Buxoro Viloyati
+85680377|Khorazm|Xorazm viloyati
+85680381|Qoraqalpoghiston|Qoraqalpogʻiston
+85680385|Navoiy viloyati|Nawoiy
+85680389|Samarqand|Samarqand viloyati
+85680395|Qashqadaryo|Qashqadaryo Viloyati
+85680397|Surkhondaryo|Surxondaryo viloyati
+85680401|Andijon|Андижон вилояти
+85680407|Farghona|Fargʻona viloyati
+85680415|Jizzakh|Jizzax viloyati
+85680419|Sirdaryo|Sirdaryo viloyati
+85680425|Toshkent|Toshkent viloyati
+85680429|Toshkent|Toshkent viloyati
+85680461|Falcon|Falcón
+85680481|Tachira|Táchira
+85680517|Bolivar|Bolívar
+85680521|Anzoategui|Anzoátegui
+85680535|Distrito Capital|Distrito Federal
+85680543|Guarico|Guárico
+85680583|Quang Ninh|Quảng Ninh
+85680589|Tay Ninh|Tây Ninh
+85680593|Dien Bien|Điện Biên
+85680597|Bac Kan|Bắc Kạn
+85680605|Thai Nguyen|Thái Nguyên
+85680607|Lai Chau|Lai Châu
+85680611|Lang Son|Lạng Sơn
+85680615|Son La|Sơn La
+85680619|Thanh Hoa|Thanh Hóa
+85680627|Tuyen Quang|Tuyên Quang
+85680629|Yen Bai|Yên Bái
+85680633|Hoa Binh|Hòa Bình
+85680637|Hai Duong|Hải Dương
+85680645|Hai Phong|Hải Phòng
+85680649|Hung Yen|Hưng Yên
+85680653|Ha Noi|Hà Nội
+85680659|Bac Ninh|Bắc Ninh
+85680663|Vinh Phuc|Vĩnh Phúc
+85680667|Ninh Binh|Ninh Bình
+85680671|Ha Nam|Hà Nam
+85680677|Nam Dinh|Nam Định
+85680681|Phu Tho|Phú Thọ
+85680685|Bac Giang|Bắc Giang
+85680689|Thai Binh|Thái Bình
+85680695|Ha Tinh|Hà Tĩnh
+85680699|Nghe An|Nghệ An
+85680703|Quang Binh|Quảng Bình
+85680707|Dak Lak|Đắk Lắk
+85680719|Khanh Hoa|Khánh Hòa
+85680723|Lam Dong|Lâm Đồng
+85680727|Ninh Thuan|Ninh Thuận
+85680733|Phu Yen|Phú Yên
+85680735|Bin Duong|Bình Dương
+85680739|Tien Giang|Tiền Giang
+85680743|Dac Nong|Đắk Nông
+85680749|Bin Phuoc|Bình Phước
+85680753|Binh Dinh|Bình Định
+85680761|Quang Nam|Quảng Nam
+85680767|Quang Ngai|Quảng Ngãi
+85680771|Quang Tri|Quảng Trị
+85680775|Thura Thien-Hue|Thừa Thiên Huế
+85680779|Da Nang|Đà Nẵng
+85680781|Ba Ria-Vung Tau|Bà Rịa - Vũng Tàu
+85680787|Binh Thuan|Bình Thuận
+85680791|Dong Nai|Đồng Nai
+85680799|Can Tho|Cần Thơ
+85680807|Dong Thap|Đồng Tháp
+85680809|Ho Chi Minh|Thành phố Hồ Chí Minh
+85680815|Kien Giang|Kiên Giang
+85680825|Ben Tre|Bến Tre
+85680827|Hau Giang|Hậu Giang
+85680833|Bac Lieu|Bạc Liêu
+85680839|Ca Mau|Cà Mau
+85680843|Soc Trang|Sóc Trăng
+85680849|Tra Vinh|Trà Vinh
+85680853|Vinh Long|Vĩnh Long
+85680859|Cao Bang|Cao Bằng
+85680863|Ha Giang|Hà Giang
+85680867|Lao Cai|Lào Cai
+85680881|Tafea|Taféa
+85680887|Penama|Pénama
+85680893|Shefa|Shéfa
+85680955|Sa`dah|صعدة
+85680959|Al Hudaydah|الحديدة
+85680965|Al Mahwit|المحويت
+85680969|Dhamar|ذمار
+85680973|Hajjah|حجة
+85680977|Amran|عمران
+85680979|Ibb|إب
+85680985|Lahij|لحج
+85680989|Ta`izz|تعز
+85680995|Al Mahrah|المهرة
+85681001|Al Bayda'|البيضاء
+85681003|Al Dali'|الضالع
+85681007|Al Jawf|الجوف
+85681011|Shabwah|شبوة
+85681015|Ma'rib|مأرب
+85681021|San`ar|صنعاء
+85681025|Hadramawt|حضرموت
+85681029|Amanat Al Asimah|أمانة العاصمة
+85681033|San`ar|ريمة
+85681039|`Adan|عدن
+85681043|Abyan|أَبْيَن
+85681103|Midlands|Midlands Province
+85681109|Mahusekwa|Mashonaland East
+85681127|Masvingo|Masvingo Province
+85681131|Mashonaland West|Mashonaland West Province
+85681155|Bajo Nuevo|Bajo Nuevo Bank
+85681187|Kuzey Kıbrıs Türk Cumhuriyeti|Northern Cyprus|Τουρκική Δημοκρατία της Βόρειας Κύπρου
+85681213|Gaza Strip|قطاع غزة
+85681241|Isle of Man|Mannin
+85681265|Qyzylorda|Байконур
+85681267|Jammu and Kashmir|کشمیر
+85681291|Macau|中國澳門
+85681345|Minor islands of North Korea|한미 관계
+85681385|Fuerza de las Naciones Unidas de Observación de la Separación|United Nations Neutral Zone|Зона Сил ООН по наблюдению за разъединением|قوة الأمم المتحدة لمراقبة فض الاشتباك
+85681427|West Bank|الضفة الغربية‎
+85681655|Carinthia|Kärnten
+85681661|Tirol|Tyrol
+85681667|Vienna|Wien
+85681671|Lower Austria|Niederösterreich
+85681677|Oberösterreich|Upper Austria
+85681687|Steiermark|Styria
+85681691|Liège|Luik|Lüttich
+85681693|Brabant wallon|Waals-Brabant|Wallonisch-Brabant
+85681699|Namen|Namur|Namür
+85681705|Limbourg|Limburg
+85681709|Flandre occidentale|West-Vlaanderen|Westflandern
+85681713|Brussels|Brussels Hoofdstedelijk Gewest|Brüssel|Région de Bruxelles-Capitale
+85681715|Antwerpen|Anvers
+85681723|Hainaut|Henegouwen|Hennegau
+85681727|Luxembourg|Luxemburg
+85681731|Brabant flamand|Flämisch-Brabant|Vlaams-Brabant
+85681733|Flandre orientale|Oost-Vlaanderen|Ostflandern
+85681739|Smolyan|Област Смолян
+85681745|Kurdzhali|Област Кърджали
+85681749|Blagoevgrad|Област Благоевград
+85681753|Kyustendil|Област Кюстендил
+85681759|Khaskovo|Област Хасково
+85681763|Pazardzhik|Област Пазарджик
+85681767|Pernik|ПФК Миньор
+85681771|Sofiya|Награди на България
+85681779|Plovdiv|Пловдив
+85681783|Stara Zagora|Област Стара Загора
+85681785|Sofia Province|Област София
+85681793|Yambol|Област Ямбол
+85681797|Gabrovo|Област Габрово
+85681799|Sliven|Област Сливен
+85681805|Burgas|Област Бургас
+85681811|Lovech|Област Ловеч
+85681815|Ruse|Област Русе
+85681817|Vratsa|Област Враца
+85681821|Montana|Област Монтана
+85681829|Veliko Turnovo|Област Велико Търново
+85681835|Pleven|Област Плевен
+85681839|Turgovishte|Област Търговище
+85681841|Vidin|Област Видин
+85681847|Varna|Област Варна
+85681853|Shumen|Област Шумен
+85681857|Razgrad|Област Разград
+85681861|Ruse|Русе
+85681865|Dobrich|Област Добрич
+85681871|Silistra|Област Силистра
+85681891|Amapa|Amapá
+85681907|Ceara|Ceará
+85681911|Distrito Federal|Federal District
+85681921|Espirito Santo|Espírito Santo
+85681925|Goias|Goiás
+85681931|Maranhao|Maranhão
+85681947|Mato Grosso Do Sul|Mato Grosso do Sul
+85681959|Para|Pará
+85681967|Paraiba|Paraíba
+85681977|Piaui|Piauí
+85681983|Parana|Paraná
+85681991|Rio De Janeiro|Rio de Janeiro
+85681999|Rio Grande Do Norte|Rio Grande do Norte
+85682003|Rondonia|Rondônia
+85682015|Rio Grande Do Sul|Rio Grande do Sul
+85682041|Sao Paulo|São Paulo
+85682065|New Brunswick|Nouveau-Brunswick
+85682067|Northwest Territories|Territoires du Nord-Ouest
+85682075|Nouvelle-Écosse|Nova Scotia
+85682081|Prince Edward Island|Île-du-Prince-Édouard
+85682117|British Columbia|Colombie-Britannique
+85682123|Newfoundland and Labrador|Terre-Neuve-et-Labrador
+85682249|Canton Glarona|Canton de Glaris|Glarus|Kantuu Glaris
+85682255|Canton des Grisons|Cantone dei Grigioni|Graubunden|Graubünden|Kanton Graubünda
+85682263|Kanton Zoog|Zoug|Zug|Zugo
+85682269|Canton Ticino|Kanton Tessin|Tessin|Ticino
+85682275|Appenzell Innerrhoden|Appenzell Rhodes-Intérieures|Canton Appenzello Interno|Kantoo Appezöll Inneroode
+85682281|Canton Vallese|Canton du Valais|Kanton Wallis|Valais
+85682285|Canton Sciaffusa|Canton de Schaffhouse|Kanton Schafuuse|Schaffhausen
+85682291|Canton Ginevra|Canton de Genève|Geneva|Genève|Kanton Gänf
+85682297|Basel-City|Basel-Stadt|Canton Basilea Città|Canton de Bâle-Ville|Kanton Basel-Stadt
+85682301|Fribourg|Friburgo|Kanton Frybùrg
+85682305|Canton Svitto|Kanton Schwyz|Schwyz
+85682309|Canton Zurigo|Kanton Züri|Zurich|Zürich
+85682315|Canton Nidvaldo|Canton de Nidwald|Nidwalden|Nidwaudä
+85682319|Canton Lucerna|Kanton Lozärn|Lucerne|Luzern
+85682325|Canton Vaud|Kanton Waadt|Vaud
+85682329|Aargau|Argovie|Canton Argovia|Kanton Aargou
+85682337|Canton Turgovia|Kanton Thurgau|Thurgau|Thurgovie
+85682341|Canton de Saint-Gall|Cantone di San Gallo|Kanton St. Gallen|Saint Gallen|St. Gallen
+85682347|Canton Giura|Jura|Kanton Jura
+85682353|Appenzell Ausserrhoden|Appenzell Rhodes-Extérieures|Canton Appenzello Esterno|Kantoo Appezäll Osserode
+85682359|Cantone di Neuchâtel|Kanton Nöieburg|Neuchatel|Neuchâtel
+85682361|Basel-Country|Basel-Landschaft|Baselbiet|Bâle-Campagne|Canton Basilea Campagna
+85682365|Canton Soletta|Kanton Soledurn|Soleure|Solothurn
+85682371|Canton Obvaldo|Canton d'Obwald|Kanton Obwaldä|Obwalden
+85682377|Canton Uri|Canton d’Uri|Uri|Üri
+85682381|Bern|Berne|Canton Berna|Kanton Bärn
+85682389|Famagusta|Gazimağusa|Επαρχία Αμμοχώστου
+85682393|Girne|Kyrenia|Κερύνεια Αχαΐας
+85682397|Lefkoşa|Nicosia|Επαρχία Λευκωσίας
+85682401|Baf|Paphos District|Επαρχία Πάφου
+85682407|Larnaca District|Larnaka|Επαρχία Λάρνακας
+85682411|Limasol|Limassol District|Επαρχία Λεμεσού
+85682415|Jihočeský|South Bohemian
+85682419|Zlín|Zlínský
+85682423|Jihomoravský|South Moravian
+85682429|Vysocina|Vysočina
+85682433|Plzeň|Plzeňský
+85682437|Prague|Praha
+85682443|Pardubice|Pardubický
+85682447|Karlovarský|Karlovy Vary
+85682451|Moravian-Silesian|Moravskoslezský
+85682455|Olomouc|Olomoucký
+85682461|Central Bohemian|Středočeský
+85682465|Hradec Králové|Královéhradecký
+85682473|Liberec|Liberecký
+85682491|Rheinland-Pfalz|Rhineland-Palatinate
+85682513|Nordrhein-Westfalen|North Rhine-Westphalia
+85682519|Sachsen-Anhalt|Saxony-Anhalt
+85682523|Sachsen|Saxony
+85682531|Hesse|Hessen
+85682541|Thuringia|Thüringen
+85682555|Lower Saxony|Niedersachsen
+85682571|Bavaria|Bayern
+85682575|Southern|Syddanmark
+85682581|Capital|Hovedstaden
+85682589|Sjælland|Zealand
+85682593|Nordjylland|North Jutland
+85682597|Central Jutland|Midtjylland
+85682611|Minor islands of Denmark|Storstrøms Amt
+85682631|Almeria|Almería
+85682639|Avila|Ávila
+85682647|Balearic Islands|Islas Baleares
+85682675|Caceres|Cáceres
+85682679|Cadiz|Cádiz
+85682685|Castellon|Castellón
+85682697|Cordoba|Córdoba
+85682701|Corunna|La Coruña
+85682721|Gerona|Girona
+85682741|Gipuzkoa|Guipúzcoa
+85682757|Jaen|Jaén
+85682765|Leon|León
+85682769|Lleida|Lérida
+85682787|Malaga|Málaga
+85682795|Navarra|Navarre
+85682801|Orense|Ourense
+85682841|Sevilla|Seville
+85682879|Biscay|Vizcaya
+85682921|Saare maakond|Saaremaa
+85682923|Saare maakond|Saaremaa
+85682933|Saare maakond|Saaremaa
+85682963|Eesti|Estonia
+85682969|Tartu maakond|Tartumaa
+85682973|Hiiu maakond|Hiiumaa
+85683005|Lääne County|Lääne maakond
+85683021|Harju maakond|Harjumaa
+85683023|Harju maakond|Harjumaa
+85683027|Eesti|Estonia
+85683031|Jarva|Järva
+85683037|Harju maakond|Harjumaa
+85683041|Harju maakond|Harjumaa
+85683045|Harju maakond|Harjumaa
+85683059|Ida-Viru|Ida-Viru Maakond
+85683067|Nyland|Uusimaa
+85683073|Egentliga Finland|Southwest Finland|Varsinais-Suomi
+85683077|Egentliga Tavastland|Kanta-Häme|Tavastia Proper
+85683081|Kymenlaakso|Kymmenedalen
+85683085|Päijänne Tavastia|Päijänne-Tavastland|Päijät-Häme
+85683091|Paijanne Tavastia|Päijänne-Tavastland|Päijät-Häme
+85683095|Satakunnan maakunta|Satakunta
+85683099|Birkaland|Pirkanmaa
+85683103|Etelä-Karjala|South Karelia|Södra Karelen
+85683109|Etelä-Savo|Southern Savonia|Södra Savolax
+85683113|Etelä-Pohjanmaa|Southern Ostrobothnia|Södra Österbotten
+85683117|Central Finland|Keski-Suomi|Mellersta Finland
+85683119|Ostrobothnia|Pohjanmaa|Österbotten
+85683125|Central Ostrobothnia|Keski-Pohjanmaa|Mellersta Österbotten
+85683131|Norra Savolax|Northern Savonia|Pohjois-Savo
+85683133|Norra Karelen|North Karelen|Pohjois-Karjala
+85683137|Kainuu|Kajanaland
+85683143|Norra Österbotten|Northern Ostrobothnia|Pohjois-Pohjanmaa
+85683147|Lapland|Lappi|Lappland
+85683563|Cote d'Or|Côte-d'Or
+85684621|Western Greece|Δυτική Ελλάδα
+85684627|West Macedonia|Δυτική Μακεδονία
+85684631|Epirus|Ήπειρος
+85684637|Central Macedonia|Κεντρική Μακεδονία
+85684643|Peloponnese|Πελοπόννησος
+85684655|Crete|Κρήτη
+85684659|South Aegean|Νότιο Αιγαίο
+85684681|Central Greece|Στερεά Ελλάδα
+85684685|Thessaly|Θεσσαλία
+85684693|Ionian Islands|Ιόνια Νησιά
+85684697|Attica|Ατιική
+85684701|East Macedonia and Thrace|Ανατολική Μακεδονία και Θράκη
+85684733|Vukovarsko-srijemska|Vukovarsko-srijemska županija
+85684737|Licko-senjska|Ličko-senjska županija
+85684749|Brodsko-posavska|Brodsko-posavska županija
+85684753|Bjelovarsko-bilogorska|Bjelovarsko-bilogorska županija
+85684755|Sibenik|Šibensko-kninska županija
+85684763|Pozega-Slavonija|Požeško-slavonska županija
+85684765|Zagrebacka|Zagrebačka županija
+85684769|Sisacko-moslavacka|Sisačko-moslavačka županija
+85684775|Dubrovacko-neretvanska|Dubrovačko-neretvanska županija
+85684781|Splitsko-dalmatinska|Splitsko-dalmatinska županija
+85684789|Primorsko-goranska|Primorsko-goranska županija
+85684793|Viroviticko-podravska|Virovitičko-podravska županija
+85684799|Koprivnica-Krizevci|Koprivničko-križevačka županija
+85684805|Osjecko-baranjska|Osječko-baranjska županija
+85684807|Zadarska|Zadarska županija
+85684811|Grad Zagreb|Zagrebačka županija
+85684813|Krapinsko-zagorska|Krapinsko-zagorska županija
+85684819|Karlovacka|Karlovačka županija
+85684823|Medimurska|Međimurska gibanica
+85684829|Istarska|Istarska županija
+85684835|Varazdin|Varaždinska županija
+85684875|Bekes|Békés
+85684895|Gyor-Moson-Sopron|Győr-Moson-Sopron
+85684919|Borsod-Abauj Zemplen|Borsod-Abaúj-Zemplén
+85684925|Contae Chorcaí|Cork
+85684929|Contae Chorcaí|Cork
+85684931|Contae Chorcaí|Cork
+85684935|Contae Chorcaí|Cork
+85684939|Contae Chorcaí|Cork
+85684945|Corcaigh|Cork City
+85684953|Contae Phort Láirge|Waterford
+85684957|Contae Chiarraí|Kerry
+85684963|Contae Chorcaí|Cork
+85684967|Contae Loch Garman|Wexford
+85684971|Contae Thiobraid Árann Theas|South Tipperary
+85684975|Carlow|Ceatharlach
+85684979|Cill Chainnigh|Kilkenny
+85684987|Contae Luimnigh|Limerick
+85684991|Contae Chiarraí|Kerry
+85684999|Cill Mhantáin|Wicklow
+85685001|Dunlaoghaire-Rathdown|Dún Laoghaire-Ráth an Dúin
+85685005|Contae Laoighise|Laois
+85685009|Contae Átha Cliath Theas|South Dublin
+85685015|Baile Átha Cliath|Dublin City
+85685019|Contae Thiobraid Árann Thuaidh|North Tipperary
+85685025|Cill Dara|Kildare
+85685029|Contae na Gaillimhe|Galway
+85685033|Contae na Gaillimhe|Galway
+85685037|Clare|Contae an Chláir
+85685041|Contae Uíbh Fhailí|Offaly
+85685045|Fine Gall|Fingal
+85685051|Contae na Gaillimhe|Galway
+85685055|Gaillimh|Galway City
+85685059|Contae na Gaillimhe|Galway
+85685065|Contae na Gaillimhe|Galway
+85685069|Contae na Gaillimhe|Galway
+85685075|Contae na hIarmhí|Westmeath
+85685077|Contae na Gaillimhe|Galway
+85685081|Contae na Mí|Meath
+85685087|Contae Lú|Louth
+85685091|Contae an Longfoirt|Longford
+85685097|Contae na Gaillimhe|Galway
+85685101|Contae na Gaillimhe|Galway
+85685105|Contae Mhaigh Eo|Mayo
+85685109|Contae Mhaigh Eo|Mayo
+85685113|Ros Comáin|Roscommon
+85685117|Monaghan|Muineachán
+85685125|Cavan|Contae an Chabháin
+85685127|Contae Mhaigh Eo|Mayo
+85685133|Leitrim|Liatroim
+85685137|Sligeach|Sligo
+85685145|Contae Mhaigh Eo|Mayo
+85685147|Contae Dhún na nGall|Donegal
+85685151|Donegal|Dún na nGall
+85685155|Contae Chorcaí|Cork
+85685161|Contae Chiarraí|Kerry
+85685165|Contae Mhaigh Eo|Mayo
+85685169|Torino|Turin
+85685205|Valle D'Aosta|Valle D'Aosta/Vallée D'Aoste
+85685271|Bolzano|Bolzano/Bozen
+85685343|Reggio Emilia|Reggio Nell'Emilia
+85685367|Forli'-Cesena|Forlì-Cesena
+85685375|Pesaro E Urbino|Pesaro e Urbino
+85685407|Firenze|Provincia di Firenze
+85685419|Pisa|Provincia di Pisa
+85685423|Arezzo|Provincia di Arezzo
+85685461|Roma|Rome
+85685505|L'Aquila|Provincia dell’Aquila
+85685577|Reggio Di Calabria|Reggio di Calabria
+85685695|Provincia del Verbano-Cusio-Ossola|Verbano-Cusio-Ossola
+85685723|Monza E Della Brianza|Provincia di Monza
+85685727|Fermo|Provincia di Fermo
+85685731|Barletta-Andria-Trani|Provincia di Barletta-Andria-Trani
+85685741|Telšiai County|Telšių apskritis
+85685747|Klaipeda|Klaipėdos apskritis
+85685753|Marijampole|Marijampolės apskritis
+85685755|Šiauliai County|Šiaulių apskritis
+85685759|Vilniaus apskritis|Vilnius
+85685765|Alytaus apskritis|Alytus
+85685767|Taurage|Tauragės apskritis
+85685773|Kaunas|Kauno apskritis
+85685779|Panevėžio Apskritis|Panevėžys County
+85685783|Utena|Utenos apskritis
+85685789|Rucavas|Rucavas novads
+85685791|Nicas|Nīcas Novads
+85685799|Liepaja|Liepāja
+85685803|Priekules|Priekules Novads
+85685807|Vainodes|Vaiņodes novads
+85685811|Grobinas|Grobiņas Novads
+85685815|Ilukstes|Ilūkstes novads
+85685819|Aknistes|Aknīstes novads
+85685829|Durbes|Durbes novads
+85685833|Kraslavas|Krāslavas novads
+85685837|Tervetes|Tērvetes novads
+85685839|Auces|Auces novads
+85685845|Rundales|Rundāles novads
+85685851|Bauskas|Bauskas novads
+85685855|Aglonas|Aglonas Novads
+85685857|Varkavas|Vārkavas novads
+85685863|Neretas|Neretas Novads
+85685867|Aizputes|Aizputes Novads
+85685871|Skrundas|Skrundas novads
+85685875|Viesites|Viesītes novads
+85685885|Brocenu|Brocēnu novads
+85685889|Jekabpils|Jēkabpils
+85685893|Dagdas|Dagdas novads
+85685901|Pavilostas|Pāvilostas novads
+85685905|Iecavas|Iecavas Novads
+85685907|Ozolnieku|Ozolnieku novads
+85685911|Jekabpils|Jēkabpils
+85685921|Jaunpils|Jaunpils Novads
+85685925|Dobeles|Dobeles novads
+85685929|Preilu|Preiļu novads
+85685935|Saldus|Saldus novads
+85685939|Vecumnieku|Vecumnieku novads
+85685943|Livanu|Līvānu Novads
+85685947|Jaunjelgavas|Jaunjelgavas Novads
+85685957|Baldones|Baldones novads
+85685961|Alsungas|Alsungas novads
+85685965|Aizkraukles|Aizkraukles novads
+85685971|Jelgava|Jelgavas
+85685975|Skriveru|Skrīveru novads
+85685977|Riebinu|Riebiņu novads
+85685981|Olaines|Olaines Novads
+85685987|Zilupes|Zilupes novads
+85685991|Krustpils|Krustpils Novads
+85685995|Lielvardes|Lielvārdes Novads
+85685999|Kekavas|Ķekavas novads
+85686001|Rezekne|Rēzekne
+85686007|Marupes|Mārupes novads
+85686011|Keguma|Ķeguma Novads
+85686015|Salaspils|Salaspils novads
+85686017|Ikšķile|Ikšķiles Novads
+85686023|Kokneses|Kokneses Novads
+85686027|Babites|Babītes novads
+85686031|Jurmala|Jūrmala
+85686033|Stopinu|Stopiņu novads
+85686037|Ludza|Ludzas
+85686043|Kuldigas|Kuldīgas novads
+85686049|Vilanu|Viļānu novads
+85686051|Varaklanu|Varakļānu novads
+85686055|Plavinu|Pļaviņu novads
+85686061|Kandavas|Kandavas Novads
+85686065|Riga|Rīga
+85686069|Ropazi|Ropažu novads
+85686073|Garkalnes|Garkalnes Novads
+85686079|Ogres|Ogres novads
+85686083|Tukuma|Tukuma novads
+85686085|Erglu|Ērgļu Novads
+85686089|Ciblas|Ciblas novads
+85686095|Rezeknes|Rēzekne
+85686099|Malpils|Mālpils Novads
+85686103|Engures|Engures novads
+85686107|Carnikavas|Carnikavas novads
+85686113|Ādaži|Ādažu Novads
+85686117|Incukalna|Inčukalna Novads
+85686125|Mersraga|Mērsraga novads
+85686131|Lubanas|Lubānas Novads
+85686135|Siguldas|Siguldas novads
+85686139|Karsavas|Kārsavas Novads
+85686143|Madonas|Madonas novads
+85686151|Cesvaines|Cesvaines novads
+85686153|Ligatnes|Līgatnes novads
+85686157|Talsu|Talsu novads
+85686161|Sejas|Sējas novads
+85686169|Saulkrastu|Saulkrastu novads
+85686173|Amatas|Amatas novads
+85686175|Jaunpiebalgas Novads|Jaunpiepalgas
+85686179|Baltinavas|Baltinavas novads
+85686185|Rugaju|Rugāju novads
+85686189|Vecpiebalgas|Vecpiebalgas novads
+85686193|Cesu|Cēsu novads
+85686203|Krimuldas|Krimuldas Novads
+85686211|Rojas|Rojas novads
+85686215|Pargaujas|Pārgaujas novads
+85686221|Dundagas|Dundagas novads
+85686225|Raunas|Raunas novads
+85686229|Priekulu|Priekuļu novads
+85686235|Balvu|Balvu novads
+85686241|Gulbenes|Gulbenes novads
+85686249|Smiltenes|Smiltenes novads
+85686251|Vilakas|Viļakas novads
+85686257|Kocenu|Kocēnu novads
+85686261|Beverinas|Beverīnas novads
+85686265|Limbazi|Limbažu novads
+85686269|Apes|Augstākie šaurdeguna pērtiķi un cilvēks
+85686275|Strencu|Strenču novads
+85686279|Aluksnes|Alūksnes novads
+85686283|Burtnieku|Burtnieku novads
+85686287|Salacgrivas|Salacgrīvas novads
+85686293|Alojas|Alojas novads
+85686299|Nauksenu|Naukšēnu novads
+85686303|Mazsalacas|Mazsalacas Novads
+85686305|Rujienas|Rūjienas novads
+85686311|Monaco|Monaco-Ville
+85686315|Cahul|raionul Cahul
+85686331|Taraclia|raionul Taraclia
+85686335|Cahul|Районул Кахул
+85686339|Taraclia|Районул Тараклия
+85686349|Gagauzia|Găgăuzia
+85686351|Basarabeasca|Районул Басарабяска
+85686355|Leova|Районул Леова
+85686359|Cimișlia District|Районул Чимишлия
+85686365|Stefan Voda|Ștefan Vodă
+85686369|Municipiul Bender|mun.Bender
+85686373|Causeni|raionul Căușeni
+85686377|Hîncești District|Районул Хынчешть
+85686385|Ialoveni|Районул Яловень
+85686387|Nisporeni|Районул Ниспорень
+85686391|Chișinău Municipality|Educația în Republica Moldova
+85686395|Anenii Noi|АнеНий-Ной
+85686405|Raionul Strășeni|Strășeni
+85686409|Ungheni|Районул Унгень
+85686413|Criuleni|raionul Criuleni
+85686423|Calarasi|raionul Călărași
+85686427|Dubasari|raionul Dubăsari
+85686437|Fălești District|Районул Фэлешть
+85686441|Orhei|Районул Орхей
+85686445|Glodeni|Районул Глодень
+85686449|Balti|Nicolae Filip
+85686455|Telenești|Telenești District
+85686459|Sîngerei District|Районул Сынӂерей
+85686463|Rîșcani District|Районул Рышкань
+85686467|Rezina|raionul Rezina
+85686473|Raionul Șoldănești|Șoldănești District
+85686477|Florești|Florești District
+85686481|Drocia|Районул Дрокия
+85686485|Raionul Edineţ|Районул Единец
+85686497|Briceni|Районул Бричень
+85686501|Soroca|Районул Сорока
+85686505|Dondușeni District|Районул Дондушень
+85686511|Raionul Ocniţa|Районул Окниця
+85686527|Estado de México|México
+85686717|Iż-Żurrieq|Zurrieq
+85686721|Il-Qrendi|Qrendi
+85686727|Safi|Ħal Safi
+85686731|Birzebbugia|Birżebbuġa
+85686735|Kirkop|Ħal Kirkop
+85686739|L-Imqabba|Mqabba
+85686749|Ghaxaq|Ħal Għaxaq
+85686753|Santa Lucija|Santa Luċija
+85686757|Is-Siġġiewi|Siggiewi (Citta' Ferdinand)
+85686763|Dingli|Ħad-Dingli
+85686767|Iż-Żejtun|Zejtun (Citta' Beland)
+85686771|Tarxien|Ħal Tarxien
+85686775|Luqa|Ħal Luqa
+85686781|Fgura|Il-Fgura
+85686789|Zebbug (Malta) (Citta' Rohan)|Ħaż-Żebbuġ
+85686793|Bormla|Bormla (Citta'  Cospicua)
+85686803|Il-Marsa|Marsa
+85686805|Qormi (Citta' Pinto)|Ħal Qormi
+85686809|Zabbar (Citta' Hompesch)|Ħaż-Żabbar
+85686819|L-Imtarfa|Mtarfa
+85686823|Hamrun|Ħamrun
+85686829|Ix-Xgħajra|Xghajra
+85686841|Birgu (Citta' Vittoriosa)|Il-Birgu
+85686851|Attard|Ħ’Attard
+85686855|Floriana|Il-Furjana
+85686859|Balzan|Ħal Balzan
+85686863|Il-Kalkara|Kalkara
+85686871|Lija|Ħal Lija
+85686875|Rabat|Rabat (Malta)
+85686883|L-Imsida|Msida
+85686889|Il-Belt Valletta|Valletta (Citta' Umilissima)
+85686897|Iklin|L-Iklin
+85686901|San Gwann|San Ġwann
+85686907|Sliema|Tas-Sliema
+85686911|Il-Mosta|Mosta
+85686915|San Giljan|San Ġiljan
+85686919|Gharghur|Ħal Għargħur
+85686925|Is-Swieqi|Swieqi
+85686929|L-Imġarr|Mgarr
+85686937|In-Naxxar|Naxxar
+85686943|San Pawl Il-Bahar|San Pawl il-Baħar
+85686947|Il-Mellieħa|Mellieha
+85686969|Ghajnsielem u Kemmuna|Għajnsielem
+85686971|Fontana|Il-Fontana
+85686977|Ix-Xewkija|Xewkija
+85686981|Ir-Rabat|Rabat (Ghawdex) (Citta' Vittoria)
+85686985|Il-Qala|Qala
+85686989|Kercem|Ta’ Kerċem
+85686999|In-Nadur|Nadur
+85687003|Ix-Xagħra|Xaghra
+85687007|Gharb|L-Għarb
+85687013|Ghasri|L-Għasri
+85687035|Noord-Brabant|North Brabant
+85687041|South Holland|Zuid-Holland
+85687053|Noord-Holland|North Holland
+85687063|Vest-Agder|Vest-Agder fylke
+85687071|Aust-Agder|Aust-Agder fylke
+85687073|Vestfold|Vestfold fylke
+85687079|Østfold|Østfold fylke
+85687085|Rogaland|Rogaland fylke
+85687091|Telemark|Telemark fylke
+85687095|Akershus|Akershus fylke
+85687099|Hordaland|Hordaland fylke
+85687105|Buskerud|Buskerud fylke
+85687109|Oppland|Oppland fylke
+85687113|Sogn og Fjordane|Sogn og Fjordane fylke
+85687117|Hedmark|Hedmark fylke
+85687123|Møre and Romsdal|Møre og Romsdal|Møre og Romsdal fylke
+85687133|Nord-Trøndelag|Nord-Trøndelag fylke
+85687135|Nordland|Nordland fylke
+85687143|Troms|Troms fylke
+85687145|Finnmark|Finnmark fylke
+85687149|Northland Region|Te Tai-tokerau
+85687165|Te Tai-poutini|West Coast Region
+85687175|Bay of Plenty Region|Te Moana-a-Toi
+85687179|Canterbury Region|Waitaha
+85687185|Marlborough Region|Tauihu
+85687189|Hawke's Bay Region|Heretaunga
+85687195|Taranaki|Taranaki Region
+85687201|Otago Region|Ōtākou
+85687211|Murihiku|Southland Region
+85687215|Chatham Islands|Wharekauri
+85687229|Waikato|Waikato Region
+85687233|Wellington Region|Whanganui-a-Tara
+85687237|Gisborne Region|Tūranga-nui-a-Kiwa
+85687243|Auckland Region|Tāmaki-makau-rau
+85687251|Manawatu-Wanganui Region|Manawatū-Whanganui
+85687257|Mazowieckie|mazowieckie
+85687261|Łódź Voivodeship|łódzkie
+85687267|Pomorskie|pomorskie
+85687271|Zachodniopomorskie|zachodniopomorskie
+85687277|Silesian Voivodeship|śląskie
+85687283|Podlaskie|podlaskie
+85687287|Świętokrzyskie Voivodship|świętokrzyskie
+85687291|Lesser Poland Voivodeship|małopolskie
+85687295|Podkarpackie|podkarpackie
+85687301|dolnoslaskie|dolnośląskie
+85687305|Warmian-Masurian Voivodeship|warmińsko-mazurskie
+85687309|Lubelskie|lubelskie
+85687313|Opolskie|opolskie
+85687319|Kujawsko-pomorskie|kujawsko-pomorskie
+85687323|Greater Poland|wielkopolskie
+85687327|Lubuskie|lubuskie
+85687345|Ilha da Madeira|Região Autónoma da Madeira
+85687359|Setúbal|Setúbal District
+85687367|Lisboa|Lisbon
+85687395|Distrito da Guarda|Guarda
+85687415|Braganza District|Bragança
+85687455|Ilha do Faial|Região Autónoma dos Açores
+85687615|Calarasi|Călăraşi
+85687621|Ialomita|Ialomiţa
+85687633|Constanta|Constanţa
+85687637|Dâmbovita|Dâmboviţa
+85687645|Arges|Argeş
+85687655|Timis|Timiş
+85687663|Braila|Brăila
+85687667|Buzau|Buzău
+85687683|Brasov|Braşov
+85687715|Bacau|Bacău
+85687719|Mures|Mureş
+85687747|Neamt|Neamţ
+85687761|Maramureş|Maramureş County
+85687777|Botosani|Botoşani
+85687781|Samara|Самарская область
+85687787|Udmurt|Удмуртская Республика
+85687791|Chelyabinsk|Челябинская область
+85687795|Chukotka|Чукотский АО
+85687801|Bashkortostan|Республика Башкортостан
+85687809|Tomsk|Томская область
+85687813|Belgorod|Белгородская область
+85687819|Smolensk|Смоленская область
+85687825|Stavropol|Ставропольский край
+85687829|Tambov|Тамбовская область
+85687831|Tyumen|Тюменская область
+85687835|Altai|Алтайский Край
+85687843|Sakha|Республика Саха
+85687849|Oryol|Орловская область
+85687853|Vologda|Вологодская область
+85687861|Leningrad|Ленинградская область
+85687865|North Ossetia-Alania|Республика Северная Осетия-Алания
+85687869|Murmansk|Мурманская область
+85687873|Mordovia|Республика Мордовия
+85687881|Magadan|Магаданская область
+85687903|Kirov|Кировская область
+85687907|Ulyanovsk|Ульяновская область
+85687913|Karachay-Cherkess|Карачаево-Черкесская Республика
+85687917|Lipetsk|Липецкая область
+85687919|Khanty-Mansi|Ханты-Мансийский АО
+85687925|Novosibirsk|Новосибирская область
+85687931|Yamalo-Nenets|Ямало-Ненецкий АО
+85687937|Khabarovsk|Хабаровский Край
+85687949|Gorno-Altay|Республика Алтай
+85687951|Amur|Амурская область
+85687953|Kalmykia|Республика Калмыкия
+85687955|Kamchatka|Камчатский край
+85687959|Yaroslavl|Ярославская область
+85687963|Ryazan|Рязанская область
+85687971|Arkhangelsk|Архангельская область
+85687975|Perm|Пермская область
+85687981|Vladimir|Владимирская область
+85687985|Astrakhan|Астраханская область
+85687991|Yevrey|Еврейская автономная область
+85687995|Saratov|Саратовская область
+85687999|Penza|Пензенская область
+85688005|Zabaykalsky|Забайкальский край
+85688011|Kursk|Курская область
+85688015|Chechnya|Чеченская Республика
+85688023|Primorsky|Приморский край
+85688029|Krasnodar|Краснодарский край
+85688033|Rostov|Ростовская область
+85688039|Tuva|Республика Тыва
+85688043|Mari El|Республика Марий Эл
+85688047|Tver|Тверская область
+85688051|Voronezh|Воронежская область
+85688057|Nizhny Novgorod|Нижегородская область
+85688061|Khakassia|Республика Хакасия
+85688065|Tatarstan|Республика Татарстан
+85688069|Saint Petersburg|Санкт-Петербург
+85688077|Komi|Республика Коми
+85688081|Orenburg|Оренбургская область
+85688085|Moscow City|Московская область
+85688089|Kabardino-Balkar|Кабардино-Балкарская Республика
+85688095|Novgorod|Новгородская область
+85688101|Volgograd|Волгоградская область
+85688105|Kemerovo|Кемеровская область
+85688111|Chuvash|Чувашская Республика
+85688115|Kostroma|Костромская область
+85688121|Bryansk|Брянская область
+85688125|Sakhalin|Сахалин
+85688131|Kaluga|Калужская область
+85688135|Adygea|Республика Адыгея
+85688139|Krasnoyarsk|Красноярский Край
+85688153|Ivanovo|Ивановская область
+85688157|Kurgan|Курганская область
+85688161|Moscow Oblast|Московская область
+85688167|Pskov|Псковская область
+85688173|Irkutsk|Иркутская область
+85688183|Sverdlovsk|Свердловская область
+85688189|Omsk|Омская область
+85688193|Karelia|Республика Карелия
+85688197|Dagestan|Республика Дагестан
+85688203|Tula|Тульская область
+85688207|Buryat|Республика Бурятия
+85688211|Nenets|Ненецкий АО
+85688215|Kaliningrad|Калининградская область
+85688223|Pcinja|Pčinjski Okrug
+85688229|North Bačka District|Severnobački Okrug
+85688233|Branicevo District|Braničevski Okrug
+85688243|Rasinski upravni okrug|Расински управни округ
+85688255|Zlatiborski upravni okrug|Златиборски управни округ
+85688257|Severnobanatski upravni okrug|Севернобанатски округ
+85688261|Toplica|Топлички управни округ
+85688267|Podunavski upravni okrug|Подунавски управни округ
+85688273|Raska|Raški Okrug
+85688277|Zajecar|Zaječarski Okrug
+85688279|Grad Beograd|Град Београд
+85688285|Nisava|Nišavski Okrug
+85688291|Sremski upravni okrug|Сремски управни округ
+85688295|Južnobački Okrug|South Backa
+85688299|Srednjobanatski upravni okrug|Средњобанатски управни округ
+85688303|Pirotski upravni okrug|Пиротски управни округ
+85688309|Pomoravski upravni okrug|Поморавски управни округ
+85688313|Kolubarski Okrug|Kolubarski upravni okrug
+85688321|Južnobanatski Okrug|South Banat
+85688329|Jablanica|Jablanički Okrug
+85688331|Borski Okrug|Borski upravni okrug
+85688335|Macva|Mačvanski Okrug
+85688339|Trenciansky kraj|Trenčiansky kraj
+85688347|Presov|Prešovský kraj
+85688349|Zilina|Žilinský kraj
+85688355|Banska Bystrica|Banskobystrický kraj
+85688359|Kosice|Košický kraj
+85688369|Trnava|Trnavský kraj
+85688373|Bratislava|Bratislavský kraj
+85688377|Scania|Skåne
+85688395|Jonkoping|Jönköping
+85688409|Ostergotland|Östergötland
+85688411|Vastra Gotaland|Västra Götaland
+85688419|Sodermanland|Södermanland
+85688421|Orebro|Örebro
+85688425|Vastmanland|Västmanland
+85688435|Varmland|Värmland
+85688453|Gavleborg|Gävleborg
+85688457|Vasternorrland|Västernorrland
+85688461|Jamtland|Jämtland
+85688465|Vasterbotten County|Västerbotten
+85688779|Donetsk|Донецкая область|Донецька область
+85688783|Vinnytsia|Vinnyts’ka Oblast’|Винницкая область
+85688787|Sumy|Сумская область|Сумська область
+85688791|Zhytomyr|Житомирская область|Житомирська область
+85688797|Dnipropetrovs'k|Днепропетровская область|Дніпропетровська область
+85688801|Kyiv|Киевская область|Київська область
+85688805|Luhansk|Луганская область|Луганська область
+85688809|Rivne|Ровненская область|Рівненська область
+85688815|Volyn|Волинська Область|Волынская область
+85688819|Mykolaiv|Миколаївська область|Николаевская область
+85688823|Ivano-Frankivs'k|Івано-Франківська область|Ивано-Франковская область
+85688825|Chernihiv|Черниговская область|Чернігівська область
+85688831|Khmelnytskyi|Хмельницкая область|Хмельницька область
+85688835|Ternopil|Тернопольская область|Тернопільська область
+85688839|Zakarpattia|Закарпатская область|Закарпатська область
+85688843|Kherson|Херсонская область|Херсонська область
+85688851|Zaporizhia|Запорожская область|Запорізька область
+85688855|Crimea|Республика Крым
+85688859|Poltava|Полтавская область|Полтавська область
+85688863|Cherkasy|Черкасская область|Черкаська область
+85688869|Chernivtsi|Черновицкая область|Чернівецька область
+85688873|Kharkiv|Харківська область|Харьковская область
+85688877|Odessa|Одесская область|Одеська область
+85688881|Kirovohrad|Кировоградская область|Кіровоградська область
+85688887|Lviv|Львовская область|Львівська область
+136251273|Quebec|Québec
+421169867|Diiwaanu Kéedugu|Kédougou
+421171937|Sabaragamuwa|சபரகமுவ|සබරගමුව
+421172179|Tqibuli|ტყიბული
+421172395|Madhyamanchal|मध्यमाञ्चल विकास क्षेत्र
+421175045|Madhya Pashchimanchal|मध्य-पश्चिमाञ्चल विकास क्षेत्र
+421177699|Akkar|عكار
+421180203|Southern|தென் மாகாணம்|දකුණු පළාත
+421181279|Tsqaltubo|წყალტუბო
+421186197|Central|மத்திய மாகாணம்|මධ්‍යම පළාත
+421187911|Baalbek Hermel|بعلبك الهرمل
+421188005|Gori|გორი
+421190805|Sudur Pashchimanchal|सुदुर पश्चिमाञ्चल क्षेत्र
+421191965|Diiwaanu Maatam|Matam
+421192631|Western|மேல் மாகாணம்|බස්නාහිර පළාත
+421199933|Naftalan|Naftalan Şəhəri
+421200799|Uva|ஊவா|ඌව
+421202177|North Central|வடமத்திய மாகாணம்|උතුරු මැද පළාත
+421202505|Purwanchal|पूर्वाञ्चल विकास क्षेत्र
+421202507|Pashchimanchal|पश्चिमाञ्चल विकास क्षेत्र
+421202509|Mwaro|Province de Mwaro|iProvense ya Mwaro
+421203233|Diiwaanu Kafrin|Kaffrine
+421203371|North Western|வடமேல் மாகாணம்|වයඹ පළාත
+890519107|Federacija Bosne I Hercegovine|Federacija Bosne i Hercegovine|Федерација Босне и Херцеговине
+1108803081|Panjshir|ولایت پنجشیر|پنجشېر ولايت
+1108803083|Daikondi|دايکندي ولايت|ولایت دایکندی
+1108803089|Qarku i Tiranës|Tiranë
+1108803101|Mymensingh|ময়মনসিংহ
+1108804319|Tbong Khmum|ខេត្តត្បូងឃ្មុំ
+1108804831|Kirkuk|كركوك
+1108804891|Osh City|Ош
+1108804897|Naypyidaw|နေပြည်တော် ပြည်ထောင်စုနယ်မြေ
+1108804899|Kavango East|Kawango-Oos
+1108804901|Caprivi|Zambezi
+1108804903|Kavango West|Kawango-Wes
+1108805617|Puno|Punu Suyu
+1108805631|West Kordofan|غرب كردفان
+1108805681|Socotra|سقطرى
+1108805687|Hauts Bassins|Hauts-Bassins
+1108805691|Plateau Central|Plateau-Central
+1108805695|Centre Ouest|Centre-Est        
+1108805699|Centre Sud|Centre-Sud
+1108805705|Centre Est|Centre-Est        
+1108805709|Centre Nord|Centre-Nord
+1108805925|Maekel Region|المنطقة المركزية|ዞባ ማእከል
+1108805927|Anseba Region|Zoba Ānseba|أنسبا
+1108805937|Imereti|იმერეთის მხარე
+1108805941|Shida Kartli|შიდა ქართლის მხარე
+1108805943|Mtskheta-Mtianeti|მცხეთა-მთიანეთის მხარე
+1108805945|Tbilisi|თბილისი
+1108805947|Ajaria|აჭარის ავტონომიური რესპუბლიკა
+1108805951|Kvemo Kartli|ქვემო ქართლის მხარე
+1108805955|Guria|გურიის მხარე
+1108805979|Telangana|तेलंगाना
+1108805993|Kalimantan Utara|North Kalimantan
+1108806109|Bafing Region|Woroba
+1108807131|Five|प्रदेश नं. ५
+1108807139|One|प्रदेश नं. १
+1108807141|Two|प्रदेश नं. २
+1108807143|Three|प्रदेश नं. ३
+1108807159|Ariana|ولاية أريانة
+1108808409|Kyankwanzi|Wilaya ya Kyankwanzi
+1108808535|Ennedi Est|إنيدي الشرقية
+1108808537|Ennedi Ouest|إنيدي الغربية
+1108808593|Gjakova|Ђаковица
+1108808597|Prizren|Rajoni i Prizrenit|Призренски округ
+1108808599|Ferizaj|Урошевац
+1108808601|Gjilani|Гњилане
+1108808603|Prishtina|Приштина
+1108959943|Jugovzhodna Slovenija|Southeast Slovenia
+1108959945|Mura|Pomurska
+1108959947|Gorizia|Goriška
+1108959949|Central Slovenia|Osrednjeslovenska
+1108959951|Coastal–Karst|Obalno-kraška
+1108959953|Littoral–Inner Carniola|Primorsko-notranjska
+1108959955|Carinthia|Koroška
+1108959959|Savinja|Savinjska
+1108959961|Drava|Podravska
+1108959963|Central Sava|Zasavska
+1108959965|Lower Sava|Posavska
+1108959967|Gorenjska|Upper Carniola
+1175612941|Bormla|Bormla (Citta' Cospicua)
+1175612955|Il-Mellieħa|Mellieha
+1175613121|Lima|Lima Suyu
+1360666031|North Aegean|Βορείο Αιγαίο
+1360666039|Mount Athos|Άθως
+1360701001|Khyber Pakhtunkhwa|خیبرپختونخوا‬
+1360702181|South Sardinia|Sud Sardegna
+1377074351|Beqaa|البقاع
+1377074353|Baalbek-Hermel|بعلبك - الهرمل
+1377074355|North Lebanon|لبنان الشمالي
+1377074357|Akkar|عكار
+1377149569|Al-Shahaniya‎|الشحانية‎
+1377149573|Al Rayyan|الريان
+1495115971|Trøndelag|Trøndelag fylke
+1511614891|Azores|Açores
+1729834133|Singapore|Singapura|சிங்கப்பூர்|新加坡
+1745977427|Luxembourg|Luxemburg
+1762780975|Ingushetia|Ингушетия
+1796661357|Béni Mellal-Khénifra|جهة بني ملال خنيفرة
+1796661361|Dakhla-Oued Ed Dahab|Dakhla-Oued Ed-Dahab|جهة الداخلة وادي الذهب
+1796661367|Guelmim-Oued Noun|جهة كلميم واد نون
+1796661371|Laâyoune-Sakia El Hamra|جهة العيون الساقية الحمراء
+1796661373|Marrakech-Safi|Marrakesh-Safi
+1796661375|Oriental|جهة الشرق
+1796661381|Tanger-Tetouan-Al Hoceima|Tanger-Tétouan-Al Hoceïma|جهة طنجة تطوان الحسيمة
+1796791507|Jammu and Kashmir|جموں و کشمیر

--- a/src/useEndonyms.js
+++ b/src/useEndonyms.js
@@ -7,6 +7,7 @@ const logger = peliasLogger.get('wof-admin-lookup');
 // load dictionary files
 const endonyms = {
   country: loadEndonyms('country'),
+  region: loadEndonyms('region'),
   locality: loadEndonyms('locality-megacity')
 };
 

--- a/test/lookupStreamEndonymsTest.js
+++ b/test/lookupStreamEndonymsTest.js
@@ -40,6 +40,35 @@ tape('tests', (test) => {
     });
   });
 
+  test.test('endonyms - region - North Rhine Westphalia/Nordrhein-Westfalen', (t) => {
+    const inputDoc = new Document('whosonfirst', 'placetype', '1')
+      .setCentroid({ lat: 12.121212, lon: 21.212121 })
+      .addParent('region', 'North Rhine Westphalia', '85682513', 'NW');
+
+    const expectedDoc = new Document('whosonfirst', 'placetype', '1')
+      .setCentroid({ lat: 12.121212, lon: 21.212121 })
+      .addParent('region', 'North Rhine Westphalia', '85682513', 'NW')
+      .addParent('region', 'Nordrhein-Westfalen', '85682513', null) // endonym added
+      .addParent('region', 'North Rhine-Westphalia', '85682513', null); // endonym added
+
+    const resolver = {
+      lookup: (centroid, search_layers, callback) => {
+        const result = {
+          region: [{ id: 85682513, name: 'North Rhine Westphalia' }]
+        };
+        setTimeout(callback, 0, null, result);
+      }
+    };
+
+    const lookupStream = stream(resolver, { useEndonyms: true });
+    t.doesNotThrow(() => {
+      test_stream([inputDoc], lookupStream, (err, actual) => {
+        t.deepEqual(actual, [expectedDoc], 'country should have additional endonyms');
+        t.end();
+      });
+    });
+  });
+
   test.test('endonyms - locality - megacity - Rome/Roma', (t) => {
     const inputDoc = new Document('whosonfirst', 'placetype', '1')
       .setCentroid({ lat: 12.121212, lon: 21.212121 })


### PR DESCRIPTION
as mentioned in https://github.com/pelias/api/issues/1629, the work in https://github.com/pelias/wof-admin-lookup/pull/314 covered country and megacity endonyms but didn't cover the `region` placetype.

I've just landed https://github.com/pelias/wof-admin-lookup/pull/316 in order to update the existing dictionaries and then added a new dictionary for the `region` placetype here.

This work requires testing as per https://github.com/pelias/wof-admin-lookup/pull/314, there is a concern that it will adversely impact the index size, although that remains to be seen.

resolves: https://github.com/pelias/api/issues/1629