### PR TITLE
feat(localNames): prefer local names in lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Who's On First Admin Lookup module recognizes the following top-level properties
 {
   "imports": {
     "adminLookup": {
-      "enabled": true
+      "enabled": true,
+      "localizedAdminNames": false
     },
     "whosonfirst": {
       "datapath": "/path/to/wof-data"
@@ -88,7 +89,7 @@ This is particularly helpful in places where the locality name returned by the p
 
 #### Contributing
 
-The mapping files are open-data, you can find more infomation about [how the data files are generated here](https://github.com/pelias/lastline).
+The mapping files are open-data, you can find more information about [how the data files are generated here](https://github.com/pelias/lastline).
 
 In the `src/data` directory of this repository you'll find the TSV (tab separated) files named after the corresponding 3-character country code (eg. `AUS.tsv`).
 
@@ -119,6 +120,8 @@ The `weight` field is used to determine which entry is the most important, this 
 #### Configuration
 
 To enable the postal cities functionality, set `imports.adminLookup.usePostalCities` to `true` in your `pelias.json` file.
+
+To enable localized administration names, set the `imports.adminLookup.localizedAdminNames` to `true` in your `pelias.json` file.
 
 #### Advanced Configuration
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ function resolver(layers) {
 
 function localResolver(layers) {
   const datapath = peliasConfig.imports.whosonfirst.datapath;
-  return require('./src/localPipResolver')(datapath, layers);
+  const localizedAdminNames = peliasConfig.imports.adminLookup.localizedAdminNames;
+  return require('./src/localPipResolver')(datapath, layers, localizedAdminNames);
 }
 
 module.exports = {

--- a/schema.js
+++ b/schema.js
@@ -10,7 +10,8 @@ module.exports = Joi.object().keys({
       missingMetafilesAreFatal: Joi.boolean().default(false),
       usePostalCities: Joi.boolean().default(false),
       postalCitiesDataPath: Joi.string(),
-      useEndonyms: Joi.boolean().default(false)
+      useEndonyms: Joi.boolean().default(false),
+      localizedAdminNames: Joi.boolean().default(false),
     }).unknown(true),
     whosonfirst: Joi.object().keys({
       datapath: Joi.string().required(),

--- a/src/localPipResolver.js
+++ b/src/localPipResolver.js
@@ -8,13 +8,15 @@ const _ = require('lodash');
 /**
  * LocalPIPService class
  *
- * @param {object} [pipService] optional, primarily used for testing
+ * @param {string} datapath
+ * @param {Array} [layers]
+ * @param {boolean} [localizedAdminNames]
  * @constructor
  */
-function LocalPipService(datapath, layers) {
+function LocalPipService(datapath, layers, localizedAdminNames) {
   const self = this;
 
-  createPipService(datapath, _.defaultTo(layers, []), false, (err, service) => {
+  createPipService(datapath, _.defaultTo(layers, []), localizedAdminNames, (err, service) => {
     if (err) {
       throw err;
     }
@@ -91,10 +93,11 @@ LocalPipService.prototype.end = function end() {
 /**
  * Factory function
  *
- * @param {object} [service]
- * @param {string} [datapath]
+ * @param {string} datapath
+ * @param {Array} [layers]
+ * @param {boolean} [localizedAdminNames]
  * @returns {LocalPIPService}
  */
-module.exports = (datapath, layers) => {
-  return new LocalPipService(datapath, layers);
+module.exports = (datapath, layers, localizedAdminNames) => {
+  return new LocalPipService(datapath, layers, localizedAdminNames);
 };

--- a/src/pip/worker.js
+++ b/src/pip/worker.js
@@ -15,7 +15,7 @@ const path = require('path');
 
 const layer = process.title = process.argv[2];
 const datapath = process.argv[3];
-const localizedAdminNames = process.argv[4];
+const localizedAdminNames = process.argv[4] == "true";
 const startTime = Date.now();
 
 const results = {


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:

This allows the [PIP-Service](https://github.com/pelias/pip-service) to return administrative names in the *local* language. It seems this feature was started and pushed to the master branch in [this commit](https://github.com/pelias/wof-admin-lookup/commit/fbc3f4dde36655688d4fad066a52cd245671c663) in 2017.  This 2017 commit involves adding a local boolean parameter called `localizedAdminNames`, which if set to `true` extracts the local name from the WOF dataset. However, I noticed some issues:

- The feature is permanently disabled by hard coding a `false` value [here](https://github.com/pelias/wof-admin-lookup/blob/362513e98b77aea632fbd4067ceb132c46be95f1/src/localPipResolver.js#L17). I do not know why this was done. I am guessing because the feature was incomplete and not tested?
- The implementation also has a small bug where the **boolean** data type of `localizedAdminNames` is converted to the **string** data type when passed into a forked child worker process [here](https://github.com/pelias/wof-admin-lookup/blob/362513e98b77aea632fbd4067ceb132c46be95f1/src/pip/index.js#L110). This leads to the correct if-branch never being taken [here](https://github.com/pelias/wof-admin-lookup/blob/362513e98b77aea632fbd4067ceb132c46be95f1/src/pip/components/extractFields.js#L58).

---
#### Here's what actually got changed :clap:

- We updated `schema.js` to include the parameter `imports.adminLookup.localizedAdminNames` in `pelias.json`. Default is set to `false` to be backward compatible.
- This configuration parameter is now read in `index.js` and passed downstream.
- We also fixed the `bool` -> `string` type change `localizedAdminNames` experiences across process boundaries in  `src/pip/worker.js`
 
---
#### Here's how others can test the changes :eyes:

I tested this by updating [PIP-Service](https://github.com/pelias/pip-service) to point to my fork. I then manually rebuilt the docker image. I then used the following `pelias.json` file:

```
{
  "logger": {
    "level": "info",
    "timestamp": false
  },
  "imports": {
    "adminLookup": {
      "enabled": true,
      "localizedAdminNames": true
    },
    "whosonfirst": {
      "datapath": "/data/whosonfirst",
      "countryCode": ["FR"],
      "importPlace": ["136253037", "85633147"]
    }
  }
}
```
and the following `docker-compose.yml`:

```
version: '3'
networks:
  default:
    driver: bridge
services:
  whosonfirst: # data download and prepartion
    image: pelias/whosonfirst:master
    container_name: pelias_whosonfirst
    user: "${DOCKER_USER}"
    volumes:
      - "./pelias.json:/code/pelias.json"
      - "${DATA_DIR}:/data"
  pip: # run-time container
    image: pelias/pip-service:master
    container_name: pelias_pip-service
    user: "${DOCKER_USER}"
    restart: always
    environment: [ "PORT=4200" ]
    ports: [ "127.0.0.1:4200:4200" ]
    volumes:
      - "./pelias.json:/code/pelias.json"
      - "${DATA_DIR}:/data"
```

When you start up `pip` it will take some time (~3-5 min) to build the in-memory spatial index. Afterward you can query the service as so: `curl http://localhost:4200/2.320957/48.871326`. You should see a response as so:

```
...
  "macroregion": [
    {
      "id": 404227465,
      "name": "Île-De-France", # without this feature it would be Ile-of-France
      "abbr": "IF",
      "centroid": { "lat": 48.709278, "lon": 2.503396 },
      "bounding_box": "1.446743,48.120537,3.558455,49.241062"
    }
  ]
...

```


We also did these tests on about 50K different GPS points in France and got a 90% exact match with our existing french-named locality lookup using a [Nominatim](https://nominatim.org/) instance. A sampling of the reaming 10% seem to be minor neighborhood differences (still in French). 

---
#### Possible Concerns

We did not test the world. There could be edge cases where this breaks? I also have concerns about why the feature was not enabled in the first place. Maybe I missed something?


