### PR TITLE
move away from event-stream, replace with stream-mock 

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "deep-diff": "^1.0.0",
-    "event-stream": "^4.0.0",
     "intercept-stdout": "^0.1.2",
     "jshint": "^2.8.0",
     "nock": "^12.0.0",
@@ -52,6 +51,7 @@
     "pelias-model": "^7.0.0",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^2.0.0",
+    "stream-mock": "^2.0.5",
     "tap-dot": "^2.0.0",
     "tape": "^5.0.0",
     "temp": "^0.9.0"

--- a/test/index.js
+++ b/test/index.js
@@ -237,3 +237,5 @@ tape('tests for main entry point', (test) => {
     t.end();
   });
 });
+
+module.exports = { test_stream };

--- a/test/index.js
+++ b/test/index.js
@@ -1,17 +1,18 @@
 'use strict';
 
 const tape = require('tape');
-const event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 const proxyquire = require('proxyquire').noCallThru();
 const through = require('through2');
 
 const stream = require('../src/lookupStream');
 
 function test_stream(input, testedStream, callback) {
-    const input_stream = event_stream.readArray(input);
-    const destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('tests for main entry point', (test) => {

--- a/test/lookupStreamEndonymsTest.js
+++ b/test/lookupStreamEndonymsTest.js
@@ -1,14 +1,15 @@
 const tape = require('tape');
-const event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 const Document = require('pelias-model').Document;
 
 const stream = require('../src/lookupStream');
 
 function test_stream(input, testedStream, callback) {
-  const input_stream = event_stream.readArray(input);
-  const destination_stream = event_stream.writeArray(callback);
-
-  input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('tests', (test) => {

--- a/test/lookupStreamEndonymsTest.js
+++ b/test/lookupStreamEndonymsTest.js
@@ -1,16 +1,8 @@
 const tape = require('tape');
-const stream_mock = require('stream-mock');
+const test_stream = require('./index').test_stream;
 const Document = require('pelias-model').Document;
 
 const stream = require('../src/lookupStream');
-
-function test_stream(input, testedStream, callback) {
-  const reader = new stream_mock.ObjectReadableMock(input);
-  const writer = new stream_mock.ObjectWritableMock();
-  writer.on('error', (e) => callback(e));
-  writer.on('finish', () => callback(null, writer.data));
-  reader.pipe(testedStream).pipe(writer);
-}
 
 tape('tests', (test) => {
   test.test('endonyms - country - Germany/Deutschland', (t) => {

--- a/test/lookupStreamPostalCityTest.js
+++ b/test/lookupStreamPostalCityTest.js
@@ -1,14 +1,15 @@
 const tape = require('tape');
-const event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 const Document = require('pelias-model').Document;
 
 const stream = require('../src/lookupStream');
 
 function test_stream(input, testedStream, callback) {
-    const input_stream = event_stream.readArray(input);
-    const destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('tests', (test) => {

--- a/test/lookupStreamPostalCityTest.js
+++ b/test/lookupStreamPostalCityTest.js
@@ -1,16 +1,8 @@
 const tape = require('tape');
-const stream_mock = require('stream-mock');
+const test_stream = require('./index').test_stream;
 const Document = require('pelias-model').Document;
 
 const stream = require('../src/lookupStream');
-
-function test_stream(input, testedStream, callback) {
-  const reader = new stream_mock.ObjectReadableMock(input);
-  const writer = new stream_mock.ObjectWritableMock();
-  writer.on('error', (e) => callback(e));
-  writer.on('finish', () => callback(null, writer.data));
-  reader.pipe(testedStream).pipe(writer);
-}
 
 tape('tests', (test) => {
   test.test('postal cities - USA lookup - ZIP 18964', (t) => {

--- a/test/lookupStreamTest.js
+++ b/test/lookupStreamTest.js
@@ -1,5 +1,5 @@
 const tape = require('tape');
-const event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 const Document = require('pelias-model').Document;
 const _ = require('lodash');
 const proxyquire = require('proxyquire').noCallThru();
@@ -7,10 +7,11 @@ const proxyquire = require('proxyquire').noCallThru();
 const stream = require('../src/lookupStream');
 
 function test_stream(input, testedStream, callback) {
-    const input_stream = event_stream.readArray(input);
-    const destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('tests', (test) => {

--- a/test/lookupStreamTest.js
+++ b/test/lookupStreamTest.js
@@ -1,18 +1,10 @@
 const tape = require('tape');
-const stream_mock = require('stream-mock');
+const test_stream = require('./index').test_stream;
 const Document = require('pelias-model').Document;
 const _ = require('lodash');
 const proxyquire = require('proxyquire').noCallThru();
 
 const stream = require('../src/lookupStream');
-
-function test_stream(input, testedStream, callback) {
-  const reader = new stream_mock.ObjectReadableMock(input);
-  const writer = new stream_mock.ObjectWritableMock();
-  writer.on('error', (e) => callback(e));
-  writer.on('finish', () => callback(null, writer.data));
-  reader.pipe(testedStream).pipe(writer);
-}
 
 tape('tests', (test) => {
   test.test('doc without centroid should not modify input', (t) => {

--- a/test/pip/components/extractFieldsLocalizedNameTest.js
+++ b/test/pip/components/extractFieldsLocalizedNameTest.js
@@ -1,13 +1,14 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 var extractFields = require('../../../src/pip/components/extractFields');
 
 
 function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
-
-  input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('extractFields localized name tests', function(test) {

--- a/test/pip/components/extractFieldsLocalizedNameTest.js
+++ b/test/pip/components/extractFieldsLocalizedNameTest.js
@@ -1,15 +1,6 @@
 var tape = require('tape');
-const stream_mock = require('stream-mock');
+const test_stream = require('../../index').test_stream;
 var extractFields = require('../../../src/pip/components/extractFields');
-
-
-function test_stream(input, testedStream, callback) {
-  const reader = new stream_mock.ObjectReadableMock(input);
-  const writer = new stream_mock.ObjectWritableMock();
-  writer.on('error', (e) => callback(e));
-  writer.on('finish', () => callback(null, writer.data));
-  reader.pipe(testedStream).pipe(writer);
-}
 
 tape('extractFields localized name tests', function(test) {
 

--- a/test/pip/components/extractFieldsTest.js
+++ b/test/pip/components/extractFieldsTest.js
@@ -1,13 +1,5 @@
 var tape = require('tape');
-const stream_mock = require('stream-mock');
-
-function test_stream(input, testedStream, callback) {
-  const reader = new stream_mock.ObjectReadableMock(input);
-  const writer = new stream_mock.ObjectWritableMock();
-  writer.on('error', (e) => callback(e));
-  writer.on('finish', () => callback(null, writer.data));
-  reader.pipe(testedStream).pipe(writer);
-}
+const test_stream = require('../../index').test_stream;
 
 tape('extractFields tests', function(test) {
   test.test('non-special case record', function(t) {

--- a/test/pip/components/extractFieldsTest.js
+++ b/test/pip/components/extractFieldsTest.js
@@ -1,11 +1,12 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 
 function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
-
-  input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('extractFields tests', function(test) {

--- a/test/pip/components/filterOutCitylessNeighbourhoodsTest.js
+++ b/test/pip/components/filterOutCitylessNeighbourhoodsTest.js
@@ -1,17 +1,9 @@
 const tape = require('tape');
-const stream_mock = require('stream-mock');
+const test_stream = require('../../index').test_stream;
 const async = require('async');
 const proxyquire = require('proxyquire').noCallThru();
 
 const filterOutCitylessNeighbourhoods = require('../../../src/pip/components/filterOutCitylessNeighbourhoods');
-
-function test_stream(input, testedStream, callback) {
-  const reader = new stream_mock.ObjectReadableMock(input);
-  const writer = new stream_mock.ObjectWritableMock();
-  writer.on('error', (e) => callback(e));
-  writer.on('finish', () => callback(null, writer.data));
-  reader.pipe(testedStream).pipe(writer);
-}
 
 tape('non-neighbourhoods tests', test => {
   const non_neighbourhoods = [

--- a/test/pip/components/filterOutCitylessNeighbourhoodsTest.js
+++ b/test/pip/components/filterOutCitylessNeighbourhoodsTest.js
@@ -1,15 +1,16 @@
 const tape = require('tape');
-const event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 const async = require('async');
 const proxyquire = require('proxyquire').noCallThru();
 
 const filterOutCitylessNeighbourhoods = require('../../../src/pip/components/filterOutCitylessNeighbourhoods');
 
 function test_stream(input, testedStream, callback) {
-    const input_stream = event_stream.readArray(input);
-    const destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('non-neighbourhoods tests', test => {

--- a/test/pip/components/filterOutHierarchylessNeighbourhoodsTest.js
+++ b/test/pip/components/filterOutHierarchylessNeighbourhoodsTest.js
@@ -1,17 +1,9 @@
 const tape = require('tape');
-const stream_mock = require('stream-mock');
+const test_stream = require('../../index').test_stream;
 const async = require('async');
 const proxyquire = require('proxyquire').noCallThru();
 
 const filterOutHierarchylessNeighbourhoods = require('../../../src/pip/components/filterOutHierarchylessNeighbourhoods');
-
-function test_stream(input, testedStream, callback) {
-  const reader = new stream_mock.ObjectReadableMock(input);
-  const writer = new stream_mock.ObjectWritableMock();
-  writer.on('error', (e) => callback(e));
-  writer.on('finish', () => callback(null, writer.data));
-  reader.pipe(testedStream).pipe(writer);
-}
 
 tape('non-neighbourhoods tests', test => {
   const non_neighbourhoods = [

--- a/test/pip/components/filterOutHierarchylessNeighbourhoodsTest.js
+++ b/test/pip/components/filterOutHierarchylessNeighbourhoodsTest.js
@@ -1,15 +1,16 @@
 const tape = require('tape');
-const event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 const async = require('async');
 const proxyquire = require('proxyquire').noCallThru();
 
 const filterOutHierarchylessNeighbourhoods = require('../../../src/pip/components/filterOutHierarchylessNeighbourhoods');
 
 function test_stream(input, testedStream, callback) {
-    const input_stream = event_stream.readArray(input);
-    const destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('non-neighbourhoods tests', test => {

--- a/test/pip/components/filterOutPointRecordsTest.js
+++ b/test/pip/components/filterOutPointRecordsTest.js
@@ -1,13 +1,14 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 
 var filterOutPointRecords = require('../../../src/pip/components/filterOutPointRecords');
 
 function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('filterOutPointNotPolygon', function (test){

--- a/test/pip/components/filterOutPointRecordsTest.js
+++ b/test/pip/components/filterOutPointRecordsTest.js
@@ -1,15 +1,7 @@
 var tape = require('tape');
-const stream_mock = require('stream-mock');
+const test_stream = require('../../index').test_stream;
 
 var filterOutPointRecords = require('../../../src/pip/components/filterOutPointRecords');
-
-function test_stream(input, testedStream, callback) {
-  const reader = new stream_mock.ObjectReadableMock(input);
-  const writer = new stream_mock.ObjectWritableMock();
-  writer.on('error', (e) => callback(e));
-  writer.on('finish', () => callback(null, writer.data));
-  reader.pipe(testedStream).pipe(writer);
-}
 
 tape('filterOutPointNotPolygon', function (test){
 	test.test('record without geometry.type should return false', function(t) {

--- a/test/pip/components/simplifyGeometryTest.js
+++ b/test/pip/components/simplifyGeometryTest.js
@@ -1,13 +1,5 @@
 var tape = require('tape');
-const stream_mock = require('stream-mock');
-
-function test_stream(input, testedStream, callback) {
-  const reader = new stream_mock.ObjectReadableMock(input);
-  const writer = new stream_mock.ObjectWritableMock();
-  writer.on('error', (e) => callback(e));
-  writer.on('finish', () => callback(null, writer.data));
-  reader.pipe(testedStream).pipe(writer);
-}
+const test_stream = require('../../index').test_stream;
 
 tape('simplifyGeometry tests', function(test) {
   test.test('Polygon geometry type should simplify first coordinates', function(t) {

--- a/test/pip/components/simplifyGeometryTest.js
+++ b/test/pip/components/simplifyGeometryTest.js
@@ -1,11 +1,12 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 
 function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
-
-  input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('simplifyGeometry tests', function(test) {


### PR DESCRIPTION
#### Here's the reason for this change :rocket:

Part of https://github.com/pelias/pelias/issues/801

#### Here's what actually got changed :clap:

Technique cribbed from https://github.com/pelias/openaddresses/pull/457

I also consolidated the test_stream function in a single place.

#### Here's how others can test the changes :eyes:

I ran the tests before and after this change with a fresh npm install.