### PR TITLE
Change order of region/macroregion layers when doing search

### DIFF
--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -20,6 +20,8 @@ const workers = {};
 const responseQueue = {};
 const wofData = {};
 
+// NB: order is important here
+// consult with https://github.com/whosonfirst/whosonfirst-placetypes when making changes
 const defaultLayers = [
   'neighbourhood',
   'borough',
@@ -27,8 +29,8 @@ const defaultLayers = [
   'localadmin',
   'county',
   'macrocounty',
-  'macroregion',
   'region',
+  'macroregion',
   'dependency',
   'country',
   'empire',
@@ -40,7 +42,10 @@ const defaultLayers = [
 module.exports.create = function createPIPService(datapath, layers, localizedAdminNames, callback) {
   // take the intersection to keep order in decreasing granularity
   // ie - _.intersection([1, 2, 3], [3, 1]) === [1, 3]
+
+
   layers = _.intersection(defaultLayers, _.isEmpty(layers) ? defaultLayers : layers);
+  console.log('CREATE PP', layers);
 
   const folder = path.join(datapath, 'sqlite');
   if (!fs.existsSync(folder)) {

--- a/src/pip/index.js
+++ b/src/pip/index.js
@@ -42,10 +42,7 @@ const defaultLayers = [
 module.exports.create = function createPIPService(datapath, layers, localizedAdminNames, callback) {
   // take the intersection to keep order in decreasing granularity
   // ie - _.intersection([1, 2, 3], [3, 1]) === [1, 3]
-
-
   layers = _.intersection(defaultLayers, _.isEmpty(layers) ? defaultLayers : layers);
-  console.log('CREATE PP', layers);
 
   const folder = path.join(datapath, 'sqlite');
   if (!fs.existsSync(folder)) {


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:

Basically how I bumped into it: we noticed that even though there is WOF data in Azerbaijan for `region` it is not returned from PIP service in many cases:

<img width="1198" alt="Screenshot 2025-03-04 at 17 01 56" src="https://github.com/user-attachments/assets/3c261eb7-34ac-47ad-ab4f-b56b61d5c93b" />

I started digging and noticed that order of layers is important, because (as I understand) we are trying to find the lowest one first and then simply use hierarchy to resolve the rest of them. Here since `marcoregion` goes first in the list of layers + there is macroregions data for Azerbaijan we basically never return region data from this service.

After changing the order it works as expected:
<img width="1712" alt="Screenshot 2025-03-04 at 17 01 12" src="https://github.com/user-attachments/assets/56719e02-b280-4a97-a3e2-e5409577bfbe" />

Worth saying that according https://github.com/whosonfirst/whosonfirst-placetypes macroregion indeed should be > region.

<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

---
#### Here's what actually got changed :clap:
- Changed order of layers 
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->

---
#### Here's how others can test the changes :eyes:
I haven't added any tests, please let me know WDYT first and then I can try come up with some test for it.

<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
