### PR TITLE
Remove stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "polygon-lookup": "^2.1.0",
     "request": "^2.83.0",
     "simplify-js": "^1.2.1",
-    "stable": "^0.1.8",
     "through2": "^3.0.0",
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",

--- a/src/postalCityMap.js
+++ b/src/postalCityMap.js
@@ -2,7 +2,6 @@
 const _ = require('lodash');
 const fs = require('fs');
 const path = require('path');
-const stable = require('stable');
 const csv = require('csv-parse/lib/sync');
 const config = require('pelias-config').generate();
 const logger = require('pelias-logger').get('wof-admin-lookup');
@@ -111,7 +110,7 @@ function loadTable(cc){
     });
 
     // re-sort the records by weight DESC in case they were provided out-of-order
-    m[postalcode] = stable(m[postalcode], (a, b) => b.weight - a.weight);
+    m[postalcode].sort((a, b) => b.weight - a.weight);
 
     // remove duplicate WOFID entries (favour the higher weighted duplicate)
     m[postalcode] = _.uniqBy(m[postalcode], 'wofid');


### PR DESCRIPTION
The npm package `stable` is deprecated:

> Modern JS already guarantees Array#sort() is a stable sort, so this
library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility

This change uses `Array#sort()` instead.

This PR replaces #322 because I can't push to the master branch to make changes. Thx @vulpivia 