### PR TITLE
Upgrade pelias-whosonfirst to v8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "pelias-config": "^4.0.0",
     "pelias-logger": "^1.2.1",
     "pelias-microservice-wrapper": "^1.2.1",
-    "pelias-whosonfirst": "^7.2.0",
+    "pelias-whosonfirst": "^8.1.0",
     "polygon-lookup": "^2.1.0",
     "request": "^2.83.0",
     "simplify-js": "^1.2.1",


### PR DESCRIPTION
This brings our `better-sqlite3` dependency up to v12.2.0 so we can support Node.js 24