### PR TITLE
Drop Nodejs 18, add Node.js 24 to CI

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version: [ 20.x, 22.x ]
+        node-version: [ 20.x, 22.x, 24.x ]
     steps:
       - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'


### PR DESCRIPTION
This drops a now EOL Node.js version from our CI, and adds the latest version, Node.js 24, to CI.

Connects https://github.com/pelias/pelias/issues/985