### PR TITLE
spatial: use spatial database for PIP lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are two possible ways to retrieve admin hierarchy: using remote
 The remote PIP service is a good option only if memory is constrained and you'd
 like to share one instance of admin lookup data across multiple importers.
 
-The Remote PIP service is automatically enabled if the `imports.services.pip.url` property exists.
+The Remote PIP service is automatically enabled if the `services.spatial.url` or `services.pip.url` properties exists.
 
 #### Local admin lookup (default, fastest)
 
@@ -53,21 +53,57 @@ It's recommended for most uses.
 
 ### Configuration
 
-Who's On First Admin Lookup module recognizes the following top-level properties in your pelias.json config file:
+Who's On First Admin Lookup module recognizes the following properties in your `pelias.json` config file:
 
-```
+note: all properties may be omitted and will default to reasonable values, `enabled` is assumed to be true if unset.
+
+```js
 {
   "imports": {
     "adminLookup": {
-      "enabled": true
-    },
+      "enabled": true,
+      "usePostalCities": true,
+      "useEndonyms": true,
+      "maxConcurrentReqs": 80
+    }
+  }
+}
+```
+
+To use the [pelias/spatial](https://github.com/pelias/spatial) module for PIP operations set:
+
+```js
+{
+  "services": {
+    "spatial": {
+      "datapath": "/path/to/spatial/databases",
+      "files": ["database.spatial.db"]
+    }
+  }
+}
+```
+
+Or to use the legacy in-memory PIP resolver, unset/delete the `services.spatial` config block and ensure the `imports.whosonfirst` config block is correctly set:
+
+```js
+{
+  "imports": {
     "whosonfirst": {
       "datapath": "/path/to/wof-data"
-    },
-    "services": {
-      "pip": {
-        "url": "https://mypipservice.com"
-      }
+    }
+  }
+}
+```
+
+If the resolver is running as an external HTTP web server, you may use the `url` property to indicate that an HTTP client will be used to access the remote service. The key may be *either* `services.spatial.url` or `services.pip.url`.
+
+This block also accepts the `timeout` and `retry` properties as defined in [microservice-wrapper](https://github.com/pelias/microservice-wrapper/blob/master/ServiceConfiguration.js).
+
+```js
+{
+  "services": {
+    "spatial": {
+      "url": "https://mypipservice.com"
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -25,6 +25,11 @@ function resolver(layers) {
 
 function localResolver(layers) {
   const datapath = peliasConfig.imports.whosonfirst.datapath;
+
+  // @todo: how best to enable spatial?
+  if (_.get(peliasConfig, 'imports.services.flag.spatial')) {
+    return require('./src/spatialPipResolver')(datapath, layers);
+  }
   return require('./src/localPipResolver')(datapath, layers);
 }
 

--- a/index.js
+++ b/index.js
@@ -1,35 +1,40 @@
-'use strict';
-
 const peliasConfig = require('pelias-config').generate(require('./schema'));
-
 const through = require('through2');
 const _ = require('lodash');
-const os = require('os');
 
 function create(layers) {
-  if (peliasConfig.imports.adminLookup.enabled) {
-    return require('./src/lookupStream')(resolver(layers),
-      peliasConfig.imports.adminLookup);
+  const config = _.get(peliasConfig, 'imports.adminLookup', {});
+  if (config.enabled) {
+    return require('./src/lookupStream')(resolver(layers), config);
   } else {
     return through.obj();
   }
 }
 
 function resolver(layers) {
-  if (_.has(peliasConfig, 'imports.services.pip')) {
-    return require('./src/remotePipResolver')(peliasConfig.imports.services.pip, layers);
-  } else {
-    return localResolver(layers);
+  // use remote pip service if the 'url' key exists in one of the supported config blocks.
+  // 'services.spatial' is the preferred config, for the legacy in-memory pip service you
+  // should use the preferred 'services.pip' config, the 'imports.services.pip' config is
+  // supported for backwards compatibility but is deprecated.
+  for (const key of ['services.spatial', 'services.pip', 'imports.services.pip']) {
+    const config = _.get(peliasConfig, key);
+    if (_.has(config, 'url')) {
+      return require('./src/remotePipResolver')(config, layers);
+    }
   }
+
+  return localResolver(layers);
 }
 
 function localResolver(layers) {
-  const datapath = peliasConfig.imports.whosonfirst.datapath;
 
-  // @todo: how best to enable spatial?
-  if (_.get(peliasConfig, 'imports.services.flag.spatial')) {
-    return require('./src/spatialPipResolver')(datapath, layers);
+  // use spatial service if configured
+  if (_.has(peliasConfig, 'services.spatial')) {
+    return require('./src/spatialPipResolver')();
   }
+
+  // otherwise use legacy local pip resolver
+  const datapath = _.get(peliasConfig, 'imports.whosonfirst.datapath', '');
   return require('./src/localPipResolver')(datapath, layers);
 }
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "pelias-config": "^4.0.0",
     "pelias-logger": "^1.2.1",
     "pelias-microservice-wrapper": "^1.2.1",
+    "pelias-spatial": "github:pelias/spatial#pip-pelias-summary",
     "pelias-whosonfirst": "^8.1.0",
     "polygon-lookup": "^2.1.0",
     "request": "^2.83.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "pelias-config": "^4.0.0",
     "pelias-logger": "^1.2.1",
     "pelias-microservice-wrapper": "^1.2.1",
-    "pelias-spatial": "github:pelias/spatial#pip-pelias-summary",
+    "pelias-spatial": "^1.0.0",
     "pelias-whosonfirst": "^8.1.0",
     "piscina": "^5.1.3",
     "polygon-lookup": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "pelias-microservice-wrapper": "^1.2.1",
     "pelias-spatial": "github:pelias/spatial#pip-pelias-summary",
     "pelias-whosonfirst": "^8.1.0",
+    "piscina": "^5.1.3",
     "polygon-lookup": "^2.1.0",
     "request": "^2.83.0",
     "simplify-js": "^1.2.1",

--- a/schema.js
+++ b/schema.js
@@ -1,11 +1,16 @@
 const Joi = require('@hapi/joi');
-const cpus = require('os').cpus;
+const os = require('os');
+
+// default parallelism for the parallelTransform stream
+// note: this value of 10x the number of cores is historical, and may be too high
+// in the future we may want to reduce it to something like 2x
+const DEFAULT_PARALLELISM = os.availableParallelism() *10;
 
 module.exports = Joi.object().keys({
   imports: Joi.object().required().keys({
     adminLookup: Joi.object().keys({
       // default maxConcurrentReqs to # of cpus/cores * 10
-      maxConcurrentReqs: Joi.number().integer().default(cpus().length*10),
+      maxConcurrentReqs: Joi.number().integer().default(DEFAULT_PARALLELISM),
       enabled: Joi.boolean().default(true),
       missingMetafilesAreFatal: Joi.boolean().default(false),
       usePostalCities: Joi.boolean().default(false),

--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const os = require('os');
 const parallelTransform = require('parallel-transform');
 const logger = require( 'pelias-logger' ).get( 'wof-admin-lookup' );
 const getAdminLayers = require( './getAdminLayers' );
@@ -102,10 +103,12 @@ module.exports = function(pipResolver, config) {
   // pelias 'imports.adminLookup' config section
   config = config || {};
 
+  console.error(pipResolver.constructor.name);
   const pipResolverStream = createPipResolverStream(pipResolver, config);
   const end = createPipResolverEnd(pipResolver);
 
-  const stream = parallelTransform(config.maxConcurrentReqs || 1, pipResolverStream);
+  const stream = parallelTransform((os.cpus().length -1)*2, pipResolverStream);
+  // const stream = parallelTransform(config.maxConcurrentReqs || 1, pipResolverStream);
   stream.on('end', end);
 
   return stream;

--- a/src/spatialPipResolver.js
+++ b/src/spatialPipResolver.js
@@ -1,95 +1,30 @@
-const path = require('node:path');
-const { Worker } = require('worker_threads');
-const os = require('os');
+const path = require('path');
+const cpus = require('os').cpus().length;
+const { Piscina, FixedQueue } = require('piscina');
 
 class SpatialPipService {
-  constructor (datapath, layers, options = {}) {
-    this.datapath = datapath;
-    this.layers = layers;
-    this.workers = [];
-    this.currentWorker = 0;
-    this.messageId = 0;
-    this.pendingRequests = new Map();
-    
-    const numWorkers = options.numWorkers || os.cpus().length -1;
-    console.error(`Initializing ${numWorkers} spatial workers`);
-    
-    for (let i = 0; i < numWorkers; i++) {
-      this.createWorker();
-    }
+  constructor (datapath) {
+    this.pool = new Piscina({
+      filename: path.resolve(__dirname, 'spatialWorker.js'),
+      workerData: {
+        dbpath: path.resolve(datapath, '..', 'spatial', 'whosonfirst-data-admin-us-latest.spatial.db')
+      },
+      minThreads: cpus -1,
+      maxThreads: cpus -1,
+      idleTimeout: Infinity,
+      maxQueue: cpus * 5,
+      taskQueue: new FixedQueue()
+    });
   }
 
-  createWorker() {
-    const worker = new Worker(path.join(__dirname, 'spatialWorker.js'), {
-      workerData: { datapath: this.datapath }
-    });
-    
-    worker.on('message', (message) => {
-      const { id, type, data } = message;
-      const pendingRequest = this.pendingRequests.get(id);
-      
-      if (pendingRequest) {
-        this.pendingRequests.delete(id);
-        
-        if (type === 'result') {
-          pendingRequest.callback(null, data);
-        } else if (type === 'error') {
-          const error = new Error(data.message);
-          error.stack = data.stack;
-          pendingRequest.callback(error);
-        }
-      }
-    });
-    
-    worker.on('error', (error) => {
-      console.error('Worker error:', error);
-    });
-    
-    worker.on('exit', (code) => {
-      if (code !== 0) {
-        console.error(`Worker stopped with exit code ${code}`);
-      }
-    });
-    
-    this.workers.push(worker);
-  }
-
-  getNextWorker() {
-    const worker = this.workers[this.currentWorker];
-    this.currentWorker = (this.currentWorker + 1) % this.workers.length;
-    return worker;
-  }
-
-  lookup(centroid, search_layers, callback) {
-    try {
-      const messageId = ++this.messageId;
-      this.pendingRequests.set(messageId, { callback });
-      
-      const worker = this.getNextWorker();
-      worker.postMessage({
-        id: messageId,
-        type: 'lookup',
-        data: {
-          centroid,
-          // search_layers
-        }
-      });
-    } catch (error) {
-      console.error('Lookup error:', error);
-      callback(error);
-    }
+  lookup(centroid, _search_layers, cb) {
+    this.pool.run({ centroid })
+      .then(result => cb(null, result))
+      .catch(error => cb(error));
   }
 
   end() {
-    console.error('Terminating spatial workers');
-    
-    this.workers.forEach(worker => {
-      worker.postMessage({ type: 'close' });
-      worker.terminate();
-    });
-    
-    this.workers = [];
-    this.pendingRequests.clear();
+    this.pool.close();
   }
 }
 

--- a/src/spatialPipResolver.js
+++ b/src/spatialPipResolver.js
@@ -1,6 +1,7 @@
-const path = require('path');
 const os = require('os');
-const { Piscina, FixedQueue } = require('piscina');
+const path = require('path');
+const logger = require('pelias-logger').get('spatial-pip-resolver');
+const { Piscina } = require('piscina');
 const THREADS = os.availableParallelism() - 1;
 
 class SpatialPipService {
@@ -9,10 +10,9 @@ class SpatialPipService {
       filename: path.resolve(__dirname, 'spatialWorker.js'),
       minThreads: THREADS,
       maxThreads: THREADS,
-      idleTimeout: Infinity,
-      maxQueue: THREADS * 20,
-      taskQueue: new FixedQueue()
+      idleTimeout: Infinity
     });
+    logger.info(`using ${THREADS} worker threads`);
   }
 
   lookup(centroid, _search_layers, cb) {

--- a/src/spatialPipResolver.js
+++ b/src/spatialPipResolver.js
@@ -1,0 +1,98 @@
+const path = require('node:path');
+const { Worker } = require('worker_threads');
+const os = require('os');
+
+class SpatialPipService {
+  constructor (datapath, layers, options = {}) {
+    this.datapath = datapath;
+    this.layers = layers;
+    this.workers = [];
+    this.currentWorker = 0;
+    this.messageId = 0;
+    this.pendingRequests = new Map();
+    
+    const numWorkers = options.numWorkers || os.cpus().length -1;
+    console.error(`Initializing ${numWorkers} spatial workers`);
+    
+    for (let i = 0; i < numWorkers; i++) {
+      this.createWorker();
+    }
+  }
+
+  createWorker() {
+    const worker = new Worker(path.join(__dirname, 'spatialWorker.js'), {
+      workerData: { datapath: this.datapath }
+    });
+    
+    worker.on('message', (message) => {
+      const { id, type, data } = message;
+      const pendingRequest = this.pendingRequests.get(id);
+      
+      if (pendingRequest) {
+        this.pendingRequests.delete(id);
+        
+        if (type === 'result') {
+          pendingRequest.callback(null, data);
+        } else if (type === 'error') {
+          const error = new Error(data.message);
+          error.stack = data.stack;
+          pendingRequest.callback(error);
+        }
+      }
+    });
+    
+    worker.on('error', (error) => {
+      console.error('Worker error:', error);
+    });
+    
+    worker.on('exit', (code) => {
+      if (code !== 0) {
+        console.error(`Worker stopped with exit code ${code}`);
+      }
+    });
+    
+    this.workers.push(worker);
+  }
+
+  getNextWorker() {
+    const worker = this.workers[this.currentWorker];
+    this.currentWorker = (this.currentWorker + 1) % this.workers.length;
+    return worker;
+  }
+
+  lookup(centroid, search_layers, callback) {
+    try {
+      const messageId = ++this.messageId;
+      this.pendingRequests.set(messageId, { callback });
+      
+      const worker = this.getNextWorker();
+      worker.postMessage({
+        id: messageId,
+        type: 'lookup',
+        data: {
+          centroid,
+          // search_layers
+        }
+      });
+    } catch (error) {
+      console.error('Lookup error:', error);
+      callback(error);
+    }
+  }
+
+  end() {
+    console.error('Terminating spatial workers');
+    
+    this.workers.forEach(worker => {
+      worker.postMessage({ type: 'close' });
+      worker.terminate();
+    });
+    
+    this.workers = [];
+    this.pendingRequests.clear();
+  }
+}
+
+module.exports = (datapath, layers) => {
+  return new SpatialPipService(datapath, layers);
+};

--- a/src/spatialPipResolver.js
+++ b/src/spatialPipResolver.js
@@ -1,18 +1,16 @@
 const path = require('path');
-const cpus = require('os').cpus().length;
+const os = require('os');
 const { Piscina, FixedQueue } = require('piscina');
+const THREADS = os.availableParallelism() - 1;
 
 class SpatialPipService {
-  constructor (datapath) {
+  constructor () {
     this.pool = new Piscina({
       filename: path.resolve(__dirname, 'spatialWorker.js'),
-      workerData: {
-        dbpath: path.resolve(datapath, '..', 'spatial', 'whosonfirst-data-admin-us-latest.spatial.db')
-      },
-      minThreads: cpus -1,
-      maxThreads: cpus -1,
+      minThreads: THREADS,
+      maxThreads: THREADS,
       idleTimeout: Infinity,
-      maxQueue: cpus * 5,
+      maxQueue: THREADS * 20,
       taskQueue: new FixedQueue()
     });
   }

--- a/src/spatialWorker.js
+++ b/src/spatialWorker.js
@@ -1,0 +1,93 @@
+const { parentPort, workerData, threadId } = require('worker_threads');
+const path = require('node:path');
+const QueryService = require('pelias-spatial/service/QueryService.js');
+const spatial = require('pelias-spatial/server/routes/pip_pelias.js');
+
+class SpatialWorker {
+  constructor(datapath) {
+    const filename = path.resolve(datapath, '..', 'spatial', 'whosonfirst-data-admin-us-latest.spatial.db');
+    console.error(`Worker ${threadId}: opening spatial database ${filename}`);
+    
+    this.service = new QueryService({
+      readonly: true,
+      filename
+    });
+  }
+
+  lookup(centroid, search_layers) {
+    return new Promise((resolve, reject) => {
+      try {
+        const req = {
+          app: { locals: { service: this.service } },
+          params: {
+            lon: centroid.lon,
+            lat: centroid.lat
+          },
+          query: {
+            layers: (search_layers || []).join(',')
+          }
+        };
+
+        const res = {
+          status: (_code) => res,
+          json: (result) => resolve(result)
+        };
+
+        spatial(req, res);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  close() {
+    if (this.service && this.service.db) {
+      this.service.db.close();
+    }
+  }
+}
+
+let worker = null;
+
+if (parentPort) {
+  worker = new SpatialWorker(workerData.datapath);
+  
+  parentPort.on('message', async (message) => {
+    const { id, type, data } = message;
+    
+    try {
+      switch (type) {
+        case 'lookup':
+          const result = await worker.lookup(data.centroid, data.search_layers);
+          parentPort.postMessage({ id, type: 'result', data: result });
+          break;
+          
+        case 'close':
+          worker.close();
+          parentPort.postMessage({ id, type: 'closed' });
+          process.exit(0);
+          break;
+          
+        default:
+          throw new Error(`Unknown message type: ${type}`);
+      }
+    } catch (error) {
+      parentPort.postMessage({ 
+        id, 
+        type: 'error', 
+        data: { 
+          message: error.message, 
+          stack: error.stack 
+        } 
+      });
+    }
+  });
+  
+  process.on('exit', () => {
+    if (worker) {
+      worker.close();
+    }
+  });
+}
+
+module.exports = SpatialWorker;

--- a/src/spatialWorker.js
+++ b/src/spatialWorker.js
@@ -1,29 +1,7 @@
-const { workerData } = require('piscina');
-const { dbpath: filename } = workerData;
-
 const QueryService = require('pelias-spatial/service/QueryService.js');
 const spatial = require('pelias-spatial/server/routes/pip_pelias.js');
+const service = new QueryService({ readonly: true, pelias: true });
 
-console.error(`Worker: opening spatial database ${filename}`);
-const service = new QueryService({ readonly: true, filename });
-
-module.exports = async function lookup({ centroid }) {
-  const req = {
-    app: { locals: { service } },
-    params: centroid,
-    query: { layers: '' }
-  };
-
-  return new Promise((resolve, reject) => {
-    const res = {
-      status: (_code) => res,
-      json: (result) => resolve(result)
-    };
-
-    try {
-      spatial(req, res);
-    } catch (error) {
-      reject(error);
-    }
-  });
+module.exports = function lookup({ centroid }) {
+  return spatial.query(service, centroid);
 };

--- a/src/spatialWorker.js
+++ b/src/spatialWorker.js
@@ -1,93 +1,29 @@
-const { parentPort, workerData, threadId } = require('worker_threads');
-const path = require('node:path');
+const { workerData } = require('piscina');
+const { dbpath: filename } = workerData;
+
 const QueryService = require('pelias-spatial/service/QueryService.js');
 const spatial = require('pelias-spatial/server/routes/pip_pelias.js');
 
-class SpatialWorker {
-  constructor(datapath) {
-    const filename = path.resolve(datapath, '..', 'spatial', 'whosonfirst-data-admin-us-latest.spatial.db');
-    console.error(`Worker ${threadId}: opening spatial database ${filename}`);
-    
-    this.service = new QueryService({
-      readonly: true,
-      filename
-    });
-  }
+console.error(`Worker: opening spatial database ${filename}`);
+const service = new QueryService({ readonly: true, filename });
 
-  lookup(centroid, search_layers) {
-    return new Promise((resolve, reject) => {
-      try {
-        const req = {
-          app: { locals: { service: this.service } },
-          params: {
-            lon: centroid.lon,
-            lat: centroid.lat
-          },
-          query: {
-            layers: (search_layers || []).join(',')
-          }
-        };
+module.exports = async function lookup({ centroid }) {
+  const req = {
+    app: { locals: { service } },
+    params: centroid,
+    query: { layers: '' }
+  };
 
-        const res = {
-          status: (_code) => res,
-          json: (result) => resolve(result)
-        };
+  return new Promise((resolve, reject) => {
+    const res = {
+      status: (_code) => res,
+      json: (result) => resolve(result)
+    };
 
-        spatial(req, res);
-      } catch (error) {
-        reject(error);
-      }
-    });
-  }
-
-  close() {
-    if (this.service && this.service.db) {
-      this.service.db.close();
-    }
-  }
-}
-
-let worker = null;
-
-if (parentPort) {
-  worker = new SpatialWorker(workerData.datapath);
-  
-  parentPort.on('message', async (message) => {
-    const { id, type, data } = message;
-    
     try {
-      switch (type) {
-        case 'lookup':
-          const result = await worker.lookup(data.centroid, data.search_layers);
-          parentPort.postMessage({ id, type: 'result', data: result });
-          break;
-          
-        case 'close':
-          worker.close();
-          parentPort.postMessage({ id, type: 'closed' });
-          process.exit(0);
-          break;
-          
-        default:
-          throw new Error(`Unknown message type: ${type}`);
-      }
+      spatial(req, res);
     } catch (error) {
-      parentPort.postMessage({ 
-        id, 
-        type: 'error', 
-        data: { 
-          message: error.message, 
-          stack: error.stack 
-        } 
-      });
+      reject(error);
     }
   });
-  
-  process.on('exit', () => {
-    if (worker) {
-      worker.close();
-    }
-  });
-}
-
-module.exports = SpatialWorker;
+};


### PR DESCRIPTION
This early draft PR allows `wof-admin-lookup` to use [pelias/spatial](https://github.com/pelias/spatial) to perform point-in-polygon operations.

the motivation for this work is to:
1. Reduce the startup time from minutes to basically instant.
2. Reduce the memory requirement from ~10GB (for the planet) to whatever you can spare for the filesystem cache.
3. Allowing for more control over the data used for admin-lookup

some potential tradeoffs are:
1. The throughput is potentially slower, we've managed to get some orders-of-magnitude gains so far, and there is potential for future improvement here. Anecdotally, on my laptop I could get 10-11k/s for the in-memory pip-service, around 5k/s when running spatial in a single thread and around 8k/s when using worker threads.
2. The spatial database needs to be downloaded in addition to the wof distribution file.
3. Any environment running `spatial` needs to have the 'runtime' installed, this used to be onerous and is now basically one line of code. If the `libspatialite` sqlite module isn't available on the system then it will fail. We can easily add this to the Docker images.

at this stage the PR contains some todo items, namely I've just adopted a naive implementation of the configuration, you need to set `imports.services.flag.spatial` to true in `~/pelias.json` and the file needs to be named `whosonfirst-data-admin-us-latest.spatial.db` in a folder relative to the whosonfirst data, this clearly isn't what we want to do, I'm open for ideas there.

```
data/spatial/whosonfirst-data-admin-us-latest.spatial.db
data/whosonfirst/sqlite/whosonfirst-data-admin-us-latest.db
```

one solution might be to add support for `pelias/config` within `pelias/spatial` itself.

full disclosure, the worker threads implementation was written by AI, I think it did a reasonable job of it.

for now this PR is open for testing and discussion, *with the goal of adopting this as the standard method of performing admin-lookup in the near future*.