### PR TITLE
spatial: support `search_layers`

### DIFF
--- a/src/spatialPipResolver.js
+++ b/src/spatialPipResolver.js
@@ -15,8 +15,8 @@ class SpatialPipService {
     logger.info(`using ${THREADS} worker threads`);
   }
 
-  lookup(centroid, _search_layers, cb) {
-    this.pool.run({ centroid })
+  lookup(centroid, layers, cb) {
+    this.pool.run(layers ? { centroid, layers } : { centroid })
       .then(result => cb(null, result))
       .catch(error => cb(error));
   }

--- a/src/spatialWorker.js
+++ b/src/spatialWorker.js
@@ -2,6 +2,10 @@ const QueryService = require('pelias-spatial/service/QueryService.js');
 const spatial = require('pelias-spatial/server/routes/pip_pelias.js');
 const service = new QueryService({ readonly: true, pelias: true });
 
-module.exports = function lookup({ centroid }) {
-  return spatial.query(service, centroid);
+module.exports = function lookup({ centroid, layers }) {
+  return spatial.query(
+    service,
+    centroid,
+    Array.isArray(layers) ? new Set(layers) : undefined
+  );
 };


### PR DESCRIPTION
This PR adds support for the `search_layers` param when using the `SpatialPipResolver`.

The parameter can be used to specify which layers are searched for the 'lowest matching admin layer'.

This functionality is already supported via the spatial HTTP endpoint (used for reverse geocoding) but wasn't considered useful for import-time PIP operations.

On reflection we are using this functionality specifically for [this function](https://github.com/pelias/wof-admin-lookup/blob/master/src/getAdminLayers.js) which ensures that Geonames doesn't replace its own Geonames admin entries with WOF ones.