### PR TITLE
postal-cities: allow disabling for some postcodes via config

### DIFF
--- a/src/postalCityMap.js
+++ b/src/postalCityMap.js
@@ -87,6 +87,18 @@ function loadTable(cc){
     }
   });
 
+  // when wofid and name columns contain a hyphen, this indicates that postal city mapping
+  // is disabled for this postalcode. This is useful for cases where the postal code is shared by
+  // multiple localities and we don't want to override the locality returned by the Point-in-Polygon query.
+  const disabled = new Set(
+    rows
+      .filter(row => row.wofid === '-' && row.name === '-')
+      .map(row => row.postalcode)
+  );
+
+  // filter out all rows with disabled postcodes
+  rows = rows.filter(row => !disabled.has(row.postalcode));
+
   // generate map
   rows.forEach(row => {
     const postalcode = normalizePostcode(row.postalcode);

--- a/test/postalCityMapTest.js
+++ b/test/postalCityMapTest.js
@@ -1,0 +1,60 @@
+const tape = require('tape');
+const proxyquire = require('proxyquire');
+
+tape('postalCityMap tests', (test) => {
+  test.test('disabled postcodes - filters all rows when postcode is disabled', (t) => {
+    // Test TSV where postcode "12345" has a valid row AND a disabled marker row
+    const tsvContent = `12345\t101\tCity A\tCA\tlocality\t100
+12345\t-\t-
+67890\t102\tCity B\tCB\tlocality\t100
+11111\t103\tCity C\tCC\tlocality\t100`;
+
+    const postalCityMap = proxyquire('../src/postalCityMap', {
+      'fs': {
+        existsSync: (path) => path.endsWith('USA.tsv'),
+        readFileSync: () => tsvContent
+      }
+    });
+
+    // Should not find postcode 12345 (disabled even though it has valid row)
+    const disabledResult = postalCityMap.lookup('USA', '12345');
+    t.notOk(disabledResult, 'should not find disabled postcode 12345');
+
+    // Should find other valid postcodes
+    const result1 = postalCityMap.lookup('USA', '67890');
+    t.ok(result1, 'should find valid postcode 67890');
+    t.equal(result1[0].name, 'City B', 'should return City B');
+
+    const result2 = postalCityMap.lookup('USA', '11111');
+    t.ok(result2, 'should find valid postcode 11111');
+    t.equal(result2[0].name, 'City C', 'should return City C');
+
+    t.end();
+  });
+
+  test.test('disabled postcodes - all rows with disabled postcode are filtered', (t) => {
+    // Test TSV where postcode "99999" appears multiple times and is marked as disabled
+    const tsvContent = `99999\t201\tDuplicate City 1\tDC1\tlocality\t100
+99999\t202\tDuplicate City 2\tDC2\tlocality\t90
+99999\t-\t-
+12345\t101\tCity A\tCA\tlocality\t100`;
+
+    const postalCityMap = proxyquire('../src/postalCityMap', {
+      'fs': {
+        existsSync: (path) => path.endsWith('USA.tsv'),
+        readFileSync: () => tsvContent
+      }
+    });
+
+    // Should not find postcode 99999 (disabled)
+    const result = postalCityMap.lookup('USA', '99999');
+    t.notOk(result, 'should not find postcode 99999 (all rows filtered)');
+
+    // Should find valid postcode
+    const validResult = postalCityMap.lookup('USA', '12345');
+    t.ok(validResult, 'should find valid postcode 12345');
+    t.equal(validResult[0].name, 'City A', 'should return City A');
+
+    t.end();
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ require ('./index.js');
 require ('./lookupStreamTest.js');
 require ('./lookupStreamPostalCityTest.js');
 require ('./lookupStreamEndonymsTest.js');
+require ('./postalCityMapTest.js');
 require ('./localPipResolverTest.js');
 require ('./remotePipResolverTest.js');
 require ('./pip/index.js');


### PR DESCRIPTION
This PR allows postal-cities mappings to be disabled for specific postcodes using the convention of a hyphen in place of *both* the WOFID and the name.

This can be helpful in some situations where the postalcode is shared my multiple localities and it's impossible to select a primary locality, in this case it's preferred to fallback to the PIP selected locality, which generally varies depending on geography.